### PR TITLE
Hey, here's that E12 fixer.  This one just does initial indent fixing.

### DIFF
--- a/autopep8.py
+++ b/autopep8.py
@@ -112,6 +112,7 @@ class FixPEP8(object):
         self.newline = find_newline(self.source)
         self.options = options
         self.indent_word = _get_indentword("".join(self.source))
+        self.logical_start = None
         # method definition
         self.fix_e111 = self.fix_e101
         self.fix_e202 = self.fix_e201
@@ -186,6 +187,143 @@ class FixPEP8(object):
             return range(1, 1 + original_length)
         else:
             return []
+
+    def find_logical(self, force=False):
+        # make a variable which is the index of all the starts of lines
+        if force is False and self.logical_start is not None:
+            return
+        def foo(source=self.source):
+            for line in source:
+                yield line
+        logical_start = []
+        logical_end = []
+        last_newline = True
+        sio = StringIO("".join(self.source))
+        parens = 0
+        for token in tokenize.generate_tokens(sio.readline):
+            if token[0] in [tokenize.COMMENT, tokenize.DEDENT,
+                            tokenize.INDENT, tokenize.NL,
+                            tokenize.ENDMARKER]:
+                continue
+            if not parens and token[0] in [
+                tokenize.NEWLINE, tokenize.SEMI
+            ]:
+                last_newline = True
+                logical_end.append((token[3][0]-1, token[2][1]))
+                continue
+            if last_newline and not parens:
+                logical_start.append((token[2][0]-1, token[2][1]))
+                last_newline = False
+            if token[0] == tokenize.OP:
+                if token[1] in '([{':
+                    parens += 1
+                elif token[1] in '}])':
+                    parens -= 1
+        self.logical_start = logical_start
+        self.logical_end = logical_end
+
+    def get_logical(self, result):
+        """return the logical line corresponding to the result.  Assumes input
+        is already E702-clean"""
+        self.find_logical()
+        row = result['line'] - 1
+        col = result['column'] - 1
+        ls = None
+        le = None
+        for i in range(0, len(self.logical_start), 1):
+            x = self.logical_end[i]
+            if x[0] > row or (x[0] == row and x[1] > col):
+                le = x
+                ls = self.logical_start[i]
+                break
+        if ls is None:
+            return []
+        original = self.source[ls[0]:le[0]+1]
+        return ls, le, original
+
+    def _fix_reindent(self, result, fix_distinct=False):
+        """Fix a badly indented line by adding or removing from its initial
+        indent only."""
+        ls, le, original = self.get_logical(result)
+        try:
+            rewrapper = Wrapper(original)
+        except tokenize.TokenError:
+            return []
+        valid_indents = rewrapper.pep8_expected()
+        if result["line"] > ls[0]:
+            # got a valid continuation line number from pep8
+            row = result["line"] - ls[0] - 1
+            # always pick the first option for this
+            valid = valid_indents[row]
+            got = rewrapper.rel_indent[row]
+        else:
+            # line number from pep8 isn't a continuation line.  instead,
+            # compare our own function's result, look for the first mismatch,
+            # and just hope that we take fewer than 100 iterations to finish.
+            for row in range(0, len(original), 1):
+                valid = valid_indents[row]
+                got = rewrapper.rel_indent[row]
+                if valid != got:
+                    break
+        line = ls[0] + row
+        orig_line = self.source[line]
+        # always pick the expected indent, for now.
+        indent_to = valid[0]
+        if fix_distinct and indent_to == 4:
+            if len(valid) == 1:
+                return []
+            else:
+                indent_to = valid[1]
+
+        if got != indent_to:
+            self.source[line] = (
+                " " * (indent_to) + orig_line.lstrip()
+            )
+        else:
+            return []
+
+    def fix_e121(self, result):
+        """The 'peculiar indent' error for hanging indents"""
+        # fix by adjusting initial indent level
+        return self._fix_reindent(result)
+
+    def fix_e122(self, result):
+        """The 'absent indent' error for hanging indents"""
+        # fix by adding an initial indent
+        return self._fix_reindent(result)
+
+    def fix_e123(self, result):
+        """The 'loose fingernails' indentation level error for hanging
+        indents"""
+        # fix by deleting whitespace to the correct level
+        return self._fix_reindent(result)
+
+    def fix_e124(self, result):
+        """The 'loose fingernails' indentation level error for visual
+        indents"""
+        # fix by inserting whitespace before the closing bracket
+        return self._fix_reindent(result)
+
+    def fix_e125(self, result):
+        """The 'often not visually distinct' error."""
+        # fix by indenting the line in error to the next stop.
+        return self._fix_reindent(result, fix_distinct=True)
+
+    def fix_e126(self, result):
+        """The 'spectacular indent' error for hanging indents"""
+        # fix by deleting whitespace to the left
+        return self._fix_reindent(result)
+
+    def fix_e127(self, result):
+        """The 'interpretive dance' indentation error."""
+        # fix by deleting whitespace to the correct level
+        return self._fix_reindent(result)
+
+    def fix_e128(self, result):
+        """The 'I just wrap long lines with a line break in the middle of my
+        argument list' indentation error."""
+        # fix by deleting whitespace to the correct level
+        return self._fix_reindent(result)
 
     def fix_e201(self, result):
         line_index = result['line'] - 1
@@ -996,6 +1134,257 @@ class Reindenter(object):
             self.find_stmt = 0
             if line:   # not endmarker
                 self.stats.append((sline, self.level))
+
+
+class Wrapper(object):
+    """Class for functions relating to continuation lines and line folding.
+    Each instance operates on a single logical line.
+    """
+    SKIP_TOKENS = frozenset([
+        tokenize.COMMENT, tokenize.NL, tokenize.INDENT,
+        tokenize.DEDENT, tokenize.NEWLINE, tokenize.ENDMARKER
+    ])
+
+    def __init__(self, physical_lines, hard_wrap=79, soft_wrap=72):
+        if type(physical_lines) != list:
+            physical_lines = physical_lines.splitlines(keepends=True)
+        self.lines = physical_lines
+        self.index = 0
+        self.hard_wrap = hard_wrap
+        self.soft_wrap = soft_wrap
+        self.tokens = list()
+        sio = StringIO("".join(physical_lines))
+        max_seen = -1
+        for token in tokenize.generate_tokens(sio.readline):
+            if token[0] != tokenize.ENDMARKER:
+                #if token[2][0] > max_seen:
+                    #max_seen = token[2][0]
+                    #print ">>" + repr(token[4]) + "<<"
+                self.tokens.append(token)
+        self.logical_line, self.mapping = self.build_tokens_logical(
+            self.tokens
+        )
+
+    def build_tokens_logical(self, tokens):
+        """
+        Build a logical line from a list of tokens.  Returns the logical line
+        and a list of (offset, token) tuples.  Does not mute strings like the
+        version in pep8.py.
+        """
+        # from pep8.py with minor modifications
+        mapping = []
+        logical = []
+        length = 0
+        previous = None
+        for token in tokens:
+            token_type, text = token[0:2]
+            if token_type in self.SKIP_TOKENS:
+                continue
+            if previous:
+                end_line, end = previous[3]
+                start_line, start = token[2]
+                if end_line != start_line:  # different row
+                    prev_text = self.lines[end_line - 1][end - 1]
+                    if prev_text == ',' or (prev_text not in '{[('
+                                            and text not in '}])'):
+                        logical.append(' ')
+                        length += 1
+                elif end != start:  # different column
+                    fill = self.lines[end_line - 1][end:start]
+                    logical.append(fill)
+                    length += len(fill)
+            mapping.append((length, token))
+            logical.append(text)
+            length += len(text)
+            previous = token
+        logical_line = ''.join(logical)
+        assert logical_line.lstrip() == logical_line
+        assert logical_line.rstrip() == logical_line
+        return logical_line, mapping
+
+    def pep8_expected(self):
+        """Helper function which replicates logic in pep8.py, to know what
+        level to indent things to.
+
+        Returns a list of lists; each list represents valid indent levels for
+        the line in question, relative from the initial indent.  However, the
+        first entry is the indent level which was expected.
+        """
+
+        # what follows is an adjusted version of
+        # pep8.py:continuation_line_indentation.  All of the comments have been
+        # stripped and the 'yield' statements replaced with 'pass'.
+        tokens = self.tokens
+
+        first_row = tokens[0][2][0]
+        nrows = 1 + tokens[-1][2][0] - first_row
+
+        # here are the return values
+        valid_indents = [list()] * nrows
+        indent_level = tokens[0][2][1]
+        valid_indents[0].append(indent_level)
+
+        if nrows == 1:
+            # bug, really.
+            return valid_indents
+
+        indent_next = self.logical_line.endswith(':')
+
+        row = depth = 0
+        parens = [0] * nrows
+        self.rel_indent = rel_indent = [0] * nrows
+        indent = [indent_level]
+        indent_chances = {}
+        last_indent = (0, 0)
+
+        for token_type, text, start, end, line in self.tokens:
+            newline = row < start[0] - first_row
+            if newline:
+                row = start[0] - first_row
+                newline = (not last_token_multiline and
+                           token_type not in (tokenize.NL, tokenize.NEWLINE))
+
+            if newline:
+                # this is where the differences start.  instead of looking at
+                # the line and determining whether the observed indent matches
+                # our expectations, we decide which type of indentation is in
+                # use at the given indent level, and return the offset.  this
+                # algorithm is succeptable to "carried errors", but should
+                # through repeated runs eventually solve indentation for
+                # multi-line expressions less than PEP8_PASSES_MAX lines long.
+
+                if depth:
+                    for open_row in range(row - 1, -1, -1):
+                        if parens[open_row]:
+                            break
+                else:
+                    open_row = 0
+
+                # that's all we get to work with.  this code attempts to
+                # "reverse" the below logic, and place into the valid indents
+                # list
+                vi = []
+                add_second_chances = False
+                if token_type == tokenize.OP and text in ']})':
+                    # this line starts with a closing bracket, so it needs to
+                    # be closed at the same indent as the opening one.
+                    if indent[depth]:
+                        # hanging indent
+                        vi.append(indent[depth])
+                    else:
+                        # visual indent
+                        vi.append(rel_indent[open_row])
+                elif depth and indent[depth]:
+                    # visual indent was previously confirmed.
+                    vi.append(indent[depth])
+                    add_second_chances = True
+                elif depth and True in indent_chances.values():
+                    # visual indent happened before, so stick to
+                    # visual indent this time.
+                    if depth > 1 and indent[depth - 1]:
+                        vi.append(indent[depth - 1])
+                    else:
+                        # stupid fallback
+                        vi.append(indent_level + 4)
+                    add_second_chances = True
+                elif not depth:
+                    vi.append(indent_level + 4)
+                else:
+                    # must be in hanging indent
+                    hang = rel_indent[open_row] + 4;
+                    vi.append(indent_level + hang)
+
+                # about the best we can do without look-ahead
+                if indent_next and vi[0] == indent_level + 4 and \
+                        nrows == row + 1:
+                    vi[0] += 4
+
+                if add_second_chances:
+                    # visual indenters like to line things up.
+                    min_indent = vi[0]
+                    for col, what in indent_chances.iteritems():
+                        if col > min_indent and (
+                            what is True or
+                            (what == str and token_type == tokenize.STRING) or
+                            (what == text and token_type == tokenize.OP)
+                        ):
+                            vi.append(col)
+                    vi = sorted(vi)
+                
+                valid_indents[row] = vi
+                
+                # ...returning to original continuation_line_identation func...
+                visual_indent = indent_chances.get(start[1])
+                last_indent = start
+                rel_indent[row] = start[1] - indent_level
+                hang = rel_indent[row] - rel_indent[open_row]
+
+                if token_type == tokenize.OP and text in ']})':
+                    if indent[depth]:
+                        if start[1] != indent[depth]:
+                            pass  #E124
+                    elif hang:
+                        pass  # E123
+                elif visual_indent is True:
+                    if not indent[depth]:
+                        indent[depth] = start[1]
+                elif visual_indent in (text, str):
+                    pass
+                elif indent[depth] and start[1] < indent[depth]:
+                    pass  #E128
+                elif hang == 4 or (indent_next and rel_indent[row] == 8):
+                    pass
+                else:
+                    if hang <= 0:
+                        pass  # E122
+                    elif indent[depth]:
+                        pass  # E127
+                    elif hang % 4:
+                        pass  # E121
+                    else:
+                        pass  # E126
+
+            # line altered: comments shouldn't define a visual indent
+            if parens[row] and not indent[depth] and token_type not in (
+                tokenize.NL, tokenize.COMMENT
+            ):
+                indent[depth] = start[1]
+                indent_chances[start[1]] = True
+            elif token_type == tokenize.STRING or text in (
+                'u', 'ur', 'b', 'br'
+            ):
+                indent_chances[start[1]] = str
+
+            if token_type == tokenize.OP:
+                if text in '([{':
+                    depth += 1
+                    indent.append(0)
+                    parens[row] += 1
+                elif text in ')]}' and depth > 0:
+                    prev_indent = indent.pop() or last_indent[1]
+                    for d in range(depth):
+                        if indent[d] > prev_indent:
+                            indent[d] = 0
+                    for ind in list(indent_chances):
+                        if ind >= prev_indent:
+                            del indent_chances[ind]
+                    depth -= 1
+                    if depth:
+                        indent_chances[indent[depth]] = True
+                    for idx in range(row, -1, -1):
+                        if parens[idx]:
+                            parens[idx] -= 1
+                            break
+                assert len(indent) == depth + 1
+                if start[1] not in indent_chances:
+                    indent_chances[start[1]] = text
+
+            last_token_multiline = (start[0] != end[0])
+
+        if indent_next and rel_indent[-1] == 4:
+            pass  #E125
+
+        return valid_indents
 
 
 def _leading_space_count(line):

--- a/test/test_autopep8.py
+++ b/test/test_autopep8.py
@@ -250,6 +250,23 @@ def foo():
         self._inner_setup(line)
         self.assertEqual(self.result, fixed)
 
+    def test_e12_reindent(self):
+        #import pdb; pdb.set_trace()
+        line = """
+
+def foo_bar(baz, frop,
+    fizz, bang):
+    pass
+"""
+        fixed = """
+
+def foo_bar(baz, frop,
+            fizz, bang):
+    pass
+"""
+        self._inner_setup(line)
+        self.assertEqual(self.result, fixed)
+
     def test_e191(self):
         line = """
 while True:
@@ -446,13 +463,13 @@ class Foo(object):
 
     def test_e261_with_dictionary(self):
         line = "d = {# comment\n1: 2}\n"
-        fixed = "d = {  # comment\n1: 2}\n"
+        fixed = "d = {  # comment\n    1: 2}\n"
         self._inner_setup(line)
         self.assertEqual(self.result, fixed)
 
     def test_e261_with_dictionary_no_space(self):
         line = "d = {#comment\n1: 2}\n"
-        fixed = "d = {  # comment\n1: 2}\n"
+        fixed = "d = {  # comment\n    1: 2}\n"
         self._inner_setup(line)
         self.assertEqual(self.result, fixed)
 
@@ -570,7 +587,7 @@ class Foo(object):
 """
         fixed = \
 """print(111, 111, 111, 111, 222, 222, 222, 222, 222, 222, 222, 222, 222, 333,
-    333, 333, 333)
+      333, 333, 333)
 """
         self._inner_setup(line)
         self.assertEqual(self.result, fixed)
@@ -583,7 +600,7 @@ class Foo(object):
         fixed = \
 """def d():
     print(111, 111, 111, 111, 222, 222, 222, 222, 222, 222, 222, 222,
-        222, 333, 333, 333, 333)
+          222, 333, 333, 333, 333)
 """
         self._inner_setup(line)
         self.assertEqual(self.result, fixed)
@@ -697,8 +714,8 @@ class Foo(object):
         self.assertEqual(self.result, fixed)
 
     def test_e502(self):
-        line = "print('abc'\\\n'def')\n"
-        fixed = "print('abc'\n'def')\n"
+        line = "print('abc'\\\n      'def')\n"
+        fixed = "print('abc'\n      'def')\n"
         self._inner_setup(line)
         self.assertEqual(self.result, fixed)
 
@@ -874,7 +891,8 @@ class TestFixPEP8Warning(unittest.TestCase):
         # We don't support this case
         line = """
 a.has_key(
-0)
+    0
+)
 """.lstrip()
         fixed = line
         self._inner_setup(line)
@@ -923,7 +941,7 @@ a.has_key(
     @only_py2
     def test_w602_skip_complex_multiline(self):
         # We do not handle formatted multiline strings
-        line = 'raise ValueError, """\nhello %s %s""" % (1,\n2)\n'
+        line = 'raise ValueError, """\nhello %s %s""" % (\n    1, 2)\n'
         self._inner_setup(line)
         self.assertEqual(self.result, line)
 


### PR DESCRIPTION
New continuation line errors were added to pep8.py; here is a first
attempt to fix them.  A new class, Wrapper, is added which will later
have alternate strategies for resolving indention situations.  It has
a magic function which "knows" what pep8.py's E12 checker will accept,
by duplicating its tokenizing loop and emitting allowable indentation
offsets for each line.

Naturally, E12 errors are related to long line errors; for instance,
indenting a line to the requested level will often push the line past
the right margin, tripping E501.  Especially when visual indenting is
being used.  The forward plan is to refactor the newly added
_shorten_line() into Wrapper, and to add further line folding
strategies (such as "prefer hanging indent", useful for long lines
with parenthesized parts).  This should allow for attempting multiple
strategies for folding a line, with the "best" one selected
