### PR TITLE
Introduced --e701-exclude-classes and --e701-exclude-callables options.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -16,3 +16,4 @@ Patches, Bug Reports, and Suggestions
 - tomscytale (https://github.com/tomscytale)
 - Filip Noetzel (https://github.com/peritus)
 - Erik Bray (https://github.com/iguananaut)
+- Christopher Medrela (https://github.com/chrismedrela)

--- a/test/test_autopep8.py
+++ b/test/test_autopep8.py
@@ -2431,6 +2431,18 @@ def foo(
         with autopep8_context(line) as result:
             self.assertEqual(fixed, result)
 
+    def test_e701_group_of_classes(self):
+        line = 'class Foo(object): pass\nclass Bar(object): pass\n'
+        fixed = 'class Foo(object): pass\nclass Bar(object): pass\n'
+        with autopep8_context(line, options=['--select=E701']) as result:
+            self.assertEqual(fixed, result)
+
+    def test_e701_group_of_defs(self):
+        line = 'def foo(): pass\ndef bar(): pass\n'
+        fixed = 'def foo(): pass\ndef bar(): pass\n'
+        with autopep8_context(line, options=['--select=E701']) as result:
+            self.assertEqual(fixed, result)
+
     def test_e702(self):
         line = 'print 1; print 2\n'
         fixed = 'print 1\nprint 2\n'


### PR DESCRIPTION
I find it quite useful. For example, consider this code:

```
class CustomException(Exception): pass
class AnotherException(Exception): pass
class YetAnotherException(Exception): pass
```

This is absolutely fine. It's terse and more readable than this:

```
class CustomException(Exception): 
    pass


class AnotherException(Exception): 
    pass


class YetAnotherException(Exception): 
    pass
```

The same with functions/methods. Sometimes it's useful to define a helper function inside another function. It's preferred to avoid lambdas, so we type:

```
def foo(list):
    def some_helper(x): return x.bar == 'bar'
    def another_helper(x): return x.bar == 'another'
    def yet_another_helper(x): return x.bar == 'yetanother'
    (... do something ...)
```

It's better than:

```
def foo(list):
    def some_helper(x): 
        return x % 2 == 0

    def another_helper(x): 
        return x.bar == 'another'

    def yet_another_helper(x): 
        return x.bar == 'yetanother'

    (... do something ...)
```
