### PR TITLE
Changed reindentation for E125

### DIFF
--- a/autopep8.py
+++ b/autopep8.py
@@ -364,7 +364,6 @@ class FixPEP8(object):
         self.fix_e122 = self._fix_reindent
         self.fix_e123 = self._fix_reindent
         self.fix_e124 = self._fix_reindent
-        self.fix_e125 = self._fix_reindent
         self.fix_e126 = self._fix_reindent
         self.fix_e127 = self._fix_reindent
         self.fix_e128 = self._fix_reindent
@@ -555,6 +554,28 @@ class FixPEP8(object):
 
         self.source[line_index] = (
             ' ' * num_indent + target.lstrip())
+
+    def fix_e125(self, result):
+        """ Fix badly indented continuation lines when they don't distinguish
+        from the next logical line. """
+
+        num_indent = int(result['info'].split()[1])
+        line_index = result['line'] - 1
+        target = self.source[line_index]
+
+        # When multiline strings are involved, pep8 reports the error as
+        # being at the start of the multiline string, which doesn't work
+        # for us.
+        if ('"""' in target or "'''" in target):
+            return []
+
+        spaces_to_add = num_indent - len(_get_indentation(target))
+        indent = len(_get_indentation(target))
+        i = line_index
+        while len(_get_indentation(self.source[i])) >= indent:
+            self.source[i] = ' ' * spaces_to_add + self.source[i]
+            i -= 1
+        return list(range(line_index, i, -1))
 
     def fix_e201(self, result):
         """Remove extraneous whitespace."""

--- a/test/test_autopep8.py
+++ b/test/test_autopep8.py
@@ -1275,6 +1275,26 @@ x = \
         with autopep8_context(line, options=['--select=E12']) as result:
             self.assertEqual(fixed, result)
 
+    def test_e125(self):
+        line = """
+if (a and
+    b in [
+        'foo',
+    ] or
+    c):
+    pass
+"""
+        fixed = """
+if (a and
+        b in [
+            'foo',
+        ] or
+        c):
+    pass
+"""
+        with autopep8_context(line, options=['--select=E125']) as result:
+            self.assertEqual(fixed, result)
+
     def test_e125_with_multiline_string(self):
         line = """
 for foo in '''
@@ -2416,21 +2436,21 @@ def foo(sldfkjlsdfsdf, kksdfsdfsf, sdfsdfsdf, sdfsdfkdk, szdfsdfsdf,
 
     def test_e501_more_aggressive_with_def(self):
         line = """\
-def foo(sldfkjlsdfsdf, kksdfsdfsf,sdfsdfsdf, sdfsdfkdk, szdfsdfsdf, sdfsdfsdfsdlkfjsdlf, sdfsdfddf,sdfsdfsfd, sdfsdfdsf):
+def foobar(sldfkjlsdfsdf, kksdfsdfsf,sdfsdfsdf, sdfsdfkdk, szdfsdfsdf, sdfsdfsdfsdlkfjsdlf, sdfsdfddf,sdfsdfsfd, sdfsdfdsf):
     pass
 """
         fixed = """\
 
 
-def foo(
-    sldfkjlsdfsdf,
-    kksdfsdfsf,
-    sdfsdfsdf,
-    sdfsdfkdk,
-    szdfsdfsdf,
-    sdfsdfsdfsdlkfjsdlf,
-    sdfsdfddf,
-    sdfsdfsfd,
+def foobar(
+        sldfkjlsdfsdf,
+        kksdfsdfsf,
+        sdfsdfsdf,
+        sdfsdfkdk,
+        szdfsdfsdf,
+        sdfsdfsdfsdlkfjsdlf,
+        sdfsdfddf,
+        sdfsdfsfd,
         sdfsdfdsf):
     pass
 """


### PR DESCRIPTION
Consider this snippet:

```
if (a and
    b and
    c):
    pass
```

This results in E125. Autopep8 reindents it like that:

```
if (a and
    b and
        c):
    pass
```

I think that there is a better approach:

```
if (a and
        b and
        c):
    pass
```
