### PR TITLE
This solves a small reformatting problem with tuples

### DIFF
--- a/autopep8.py
+++ b/autopep8.py
@@ -63,7 +63,7 @@ except NameError:
     unicode = str
 
 
-__version__ = '1.0a0'
+__version__ = '1.0a1'
 
 
 CR = '\r'

--- a/test/test_autopep8.py
+++ b/test/test_autopep8.py
@@ -2909,14 +2909,14 @@ def foobar(
         line = """\
 def f():
     man_this_is_a_very_long_function_name(an_extremely_long_variable_name,
-                                          ('a string that is long: %s'%'foo'))
+                                          ('a string that is long: %s'%'bork'))
 """
         fixed = """\
 def f():
     man_this_is_a_very_long_function_name(
         an_extremely_long_variable_name,
         ('a string that is long: %s' %
-         'foo'))
+         'bork'))
 """
         with autopep8_context(line, options=['-aa']) as result:
             self.assertEqual(fixed, result)


### PR DESCRIPTION
```
def f():
    man_this_is_a_very_long_function_name(an_extremely_long_variable_name,
                                          ('a string that is long: %s'%'bork'))
```

becomes this:

```
def f():
    man_this_is_a_very_long_function_name(
        an_extremely_long_variable_name, ('a string that is long: %s' % 'bork'))
```

But it's still over 79 columns in length. With this patch, it formats it as this:

```
def f():
    man_this_is_a_very_long_function_name(
        an_extremely_long_variable_name,
        ('a string that is long: %s' %
         'bork'))
```
