### PR TITLE
Multiple multiline strings were not being reformatted correct.

### DIFF
--- a/test/test_autopep8.py
+++ b/test/test_autopep8.py
@@ -2816,8 +2816,10 @@ print(
     def test_e501_with_aggressive_and_multiline_string_with_addition(self):
         line = '''\
 def f():
-  email_text += """<html>This is a really long docstring that goes over the column limit and is multi-line.<br><br>
+    email_text += """<html>This is a really long docstring that goes over the column limit and is multi-line.<br><br>
 <b>Czar: </b>"""+despot["Nicholas"]+"""<br>
+<b>Minion: </b>"""+serf["Dmitri"]+"""<br>
+<b>Residence: </b>"""+palace["Winter"]+"""<br>
 </body>
 </html>"""
 '''
@@ -2825,6 +2827,9 @@ def f():
 def f():
     email_text += """<html>This is a really long docstring that goes over the column limit and is multi-line.<br><br>
 <b>Czar: </b>""" + despot["Nicholas"] + """<br>
+<b>Minion: </b>""" + serf["Dmitri"] + """<br>
+<b>Residence: </b>""" + \\
+        palace["Winter"] + """<br>
 </body>
 </html>"""
 '''
@@ -2834,18 +2839,25 @@ def f():
     def test_e501_with_aggressive_and_multiline_string_in_parens(self):
         line = '''\
 def f():
-  email_text += ("""<html>This is a really long docstring that goes over the column limit and is multi-line.<br><br>
+    email_text += ("""<html>This is a really long docstring that goes over the column limit and is multi-line.<br><br>
 <b>Czar: </b>"""+despot["Nicholas"]+"""<br>
+<b>Minion: </b>"""+serf["Dmitri"]+"""<br>
+<b>Residence: </b>"""+palace["Winter"]+"""<br>
 </body>
 </html>""")
 '''
         fixed = '''\
 def f():
-    email_text += (
-        """<html>This is a really long docstring that goes over the column limit and is multi-line.<br><br>
+    email_text += ("""<html>This is a really long docstring that goes over the column limit and is multi-line.<br><br>
 <b>Czar: </b>""" +
-        despot["Nicholas"] +
-        """<br>
+                   despot["Nicholas"] +
+                   """<br>
+<b>Minion: </b>""" +
+                   serf["Dmitri"] +
+                   """<br>
+<b>Residence: </b>""" +
+                   palace["Winter"] +
+                   """<br>
 </body>
 </html>""")
 '''


### PR DESCRIPTION
Code that had one multiline string was handled correctly. However, if
there were multiple multiline strings for a line of code, it wouldn't
format them correctly. E.g.:

```
def f():
    email_text += """<html>This is a really long docstring that goes
over the column limit and is multi-line.<br><br>
<b>Czar: </b>"""+despot["Nicholas"]+"""<br>
<b>Minion: </b>"""+serf["Dmitri"]+"""<br>
<b>Residence: </b>"""+palace["Winter"]+"""<br>
</body>
</html>"""
```

is formatted to this:

```
def f():
    email_text += """<html>This is a really long docstring that goes over the column limit and is multi-line.<br><br>
<b>Czar: </b>""" + despot["Nicholas"] + """<br>
<b>Minio
        n: </b>
        """ + serf["Dmitri"] + """<br>
<b>Residence: </b>""" + palace["Winter"] + """<br>
</body>
</html>"""
```

This patch takes the bit where it's taking multiline offsets into
account and makes it more general.
