### PR TITLE
Prefer splitting argument after list start if before a tuple.

### DIFF
--- a/autopep8.py
+++ b/autopep8.py
@@ -1374,9 +1374,10 @@ def _shorten_line_at_tokens(tokens, source, indentation, indent_word,
 
             if (
                 index > 2 and token_string == '(' and
-                tokens[index - 1][1] in ',(%'
+                tokens[index - 1][1] in ',(%['
             ):
-                # Don't split after a tuple start.
+                # Don't split after a tuple start, or before a tuple start if
+                # the tuple is in a list.
                 continue
 
             if end_offset < len(source) - 1:

--- a/test/test_autopep8.py
+++ b/test/test_autopep8.py
@@ -3034,6 +3034,22 @@ def f():
         with autopep8_context(line, options=['-aa']) as result:
             self.assertEqual(fixed, result)
 
+    def test_e501_aggressive_with_tuple_in_list(self):
+        line = """\
+def f(self):
+    self._xxxxxxxx(aaaaaa, bbbbbbbbb, cccccccccccccccccc,
+                   [('mmmmmmmmmm', self.yyyyyyyyyy.zzzzzzz/_DDDDD)], eee, 'ff')
+"""
+        fixed = """\
+def f(self):
+    self._xxxxxxxx(
+        aaaaaa, bbbbbbbbb, cccccccccccccccccc, [
+            ('mmmmmmmmmm', self.yyyyyyyyyy.zzzzzzz / _DDDDD)], eee, 'ff')
+"""
+
+        with autopep8_context(line, options=['-aa']) as result:
+            self.assertEqual(fixed, result)
+
     def test_e502(self):
         line = "print('abc'\\\n      'def')\n"
         fixed = "print('abc'\n      'def')\n"


### PR DESCRIPTION
Without this, the arguments in the following will all be placed on
individual lines after reformatting:

```
self._xxxxxxxx(aaaaaa, bbbbbbbbb, cccccccccccccccccc,
               [('mmmmmmmmmm', self.yyyyyyyyyy.zzzzzzz/_DDDDD)], eee, 'ff')
```
