### PR TITLE
Clean-up some of the reflowing logic.

### DIFF
--- a/test/test_autopep8.py
+++ b/test/test_autopep8.py
@@ -3063,6 +3063,22 @@ def f(self):
         with autopep8_context(line, options=['-aa']) as result:
             self.assertEqual(fixed, result)
 
+    def test_e501_experimental_with_complex_reformat(self):
+        line = """\
+bork(111, 111, 111, 111, 222, 222, 222, { 'foo': 222, 'qux': 222 }, ((['hello', 'world'], ['yo', 'stella', "how's", 'it'], ['going']), {str(i): i for i in range(10)}, {'bork':((x, x**x) for x in range(10))}), 222, 222, 222, 222, 333, 333, 333, 333)
+"""
+        fixed = """\
+bork(
+    111, 111, 111, 111, 222, 222, 222, {'foo': 222, 'qux': 222},
+    ((['hello', 'world'], ['yo', 'stella', "how's", 'it'], ['going']),
+     {str(i): i for i in range(10)},
+     {'bork': ((x, x ** x) for x in range(10))}), 222, 222, 222, 222, 333,
+    333, 333, 333)
+"""
+
+        with autopep8_context(line, options=['--experimental']) as result:
+            self.assertEqual(fixed, result)
+
     def test_e502(self):
         line = "print('abc'\\\n      'def')\n"
         fixed = "print('abc'\n      'def')\n"


### PR DESCRIPTION
Several code snippets weren't being reflown because the check saw an invalid indent in front of them. We also weren't taking into account the set of closing brackets when calculating if an element could exist on the current line.
