### PR TITLE
Use explicit continued indent sizes.

### DIFF
--- a/autopep8.py
+++ b/autopep8.py
@@ -1817,9 +1817,9 @@ def _reflow_lines(parsed_tokens, indentation, indent_word, max_line_length,
 
     if unicode(parsed_tokens[0]) == 'def':
         # A function definition gets indented a bit more.
-        continued_indent = indentation + indent_word * 2
+        continued_indent = indentation + ' ' * 8
     else:
-        continued_indent = indentation + indent_word
+        continued_indent = indentation + ' ' * 4
 
     break_after_open_bracket = not start_on_prefix_line
 

--- a/test/test_autopep8.py
+++ b/test/test_autopep8.py
@@ -3172,6 +3172,23 @@ def f():
         with autopep8_context(line, options=['--experimental']) as result:
             self.assertEqual(fixed, result)
 
+    def test_e501_experimental_tuple_on_line_two_space_indent(self):
+        line = """\
+def f():
+  self.aaaaaaaaa(bbbbbb, ccccccccc, dddddddddddddddd,
+                 ((x, y/eeeeeee) for x, y in self.outputs.total.iteritems()),
+                 fff, 'GG')
+"""
+        fixed = """\
+def f():
+  self.aaaaaaaaa(bbbbbb, ccccccccc, dddddddddddddddd,
+                 ((x, y / eeeeeee) for x, y in self.outputs.total.iteritems()),
+                 fff, 'GG')
+"""
+        with autopep8_context(line, options=['--experimental',
+                                             '--indent-size=2']) as result:
+            self.assertEqual(fixed, result)
+
     def test_e502(self):
         line = "print('abc'\\\n      'def')\n"
         fixed = "print('abc'\n      'def')\n"


### PR DESCRIPTION
If the '--indent-size' flag is 2, then the 'indent_word' size is also 2.
This breaks the formatting requirement that the continued indentation be
a multiple of 4 spaces. Instead of trying to calculate this, make it
explicit.
