### PR TITLE
Expand the experimental E501 tests.

### DIFF
--- a/test/test_autopep8.py
+++ b/test/test_autopep8.py
@@ -4506,14 +4506,13 @@ xxxxxxxxxxxxxxxxxxxxxxxxxxxx(
 
     def test_e501_experimental_and_multiple_logical_lines_with_math(self):
         line = """\
-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx([-1 + 5 / 10,
+xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx([-1 + 5 / -10,
                                                                             100,
                                                                             -3 - 4])
 """
-        # FIXME: The unary operators shouldn't have spaces.
         fixed = """\
 xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx(
-    [- 1 + 5 / 10, 100, - 3 - 4])
+    [-1 + 5 / -10, 100, -3 - 4])
 """
         with autopep8_context(line, options=['--experimental']) as result:
             self.assertEqual(fixed, result)


### PR DESCRIPTION
This adds "experimental" tests for all of the existing E501 test cases.
It also splits out the experimental tests into their own class.

The good thing is that virtually all tests have the same or better
output as their aggressive counterparts. However, there are a few which
have not-so-pretty output. Those have been marked with FIXMEs.
