### PR TITLE
Fix breaking before a default initializer.

### DIFF
--- a/autopep8.py
+++ b/autopep8.py
@@ -1472,7 +1472,8 @@ class ReflowedLines(object):
             # item isn't an operator that doesn't require a space.
             ((prev_item.is_keyword or prev_item.is_string or
               prev_item.is_name or prev_item.is_number) and
-             curr_text[0] not in '([{.,:}])') or
+             (curr_text[0] not in '([{.,:}])' or
+              (curr_text[0] == '=' and equal))) or
 
             # Don't place spaces around a '.', unless it's in an 'import'
             # statement.
@@ -1644,7 +1645,7 @@ class Container(object):
                         reflowed_lines.line_empty() or
                         next_text != '=' or not next_next_item or
                         reflowed_lines.fits_on_current_line(
-                            item.size + next_item.size +
+                            item_size + next_item.size +
                             next_next_item.size + depth + 2)
                     ):
                         reflowed_lines.add_space_if_needed(item_text)

--- a/test/test_autopep8.py
+++ b/test/test_autopep8.py
@@ -4212,8 +4212,8 @@ if True:
     if True:
         if True:
             blah = blah.blah_blah_blah_bla_bl(
-                blahb.blah, blah.blah, blah=blah.label, blah_blah=
-                blah_blah, blah_blah2=blah_blah)
+                blahb.blah, blah.blah, blah=blah.label,
+                blah_blah=blah_blah, blah_blah2=blah_blah)
 """
         with autopep8_context(line, options=['--experimental']) as result:
             self.assertEqual(fixed, result)


### PR DESCRIPTION
The wrong size was being used and a space was being placed in between
the argument and the '=' sign.
