### PR TITLE
Set all lib2to3 fixes tp W690.

### DIFF
--- a/autopep8.py
+++ b/autopep8.py
@@ -55,6 +55,7 @@ import signal
 import sys
 import token
 import tokenize
+from lib2to3.refactor import get_all_fix_names
 
 import pep8
 
@@ -97,20 +98,8 @@ CODE_TO_2TO3 = {
     'W601': ['has_key'],
     'W603': ['ne'],
     'W604': ['repr'],
-    'W690': ['apply',
-             'except',
-             'exitfunc',
-             'import',
-             'numliterals',
-             'operator',
-             'paren',
-             'reduce',
-             'renames',
-             'standarderror',
-             'sys_exc',
-             'throw',
-             'tuple_params',
-             'xreadlines']}
+    'W690': set(get_all_fix_names('lib2to3.fixes')) -
+    set(['idioms', 'ne', 'repr', 'print', 'execfile', 'raise'])}
 
 
 def open_with_encoding(filename, encoding=None, mode='r'):


### PR DESCRIPTION
I found lib2to3 can fix 52 kinds of types. but here only especially the 14 kinds.

according to issue # 93, I did not find the reason, I do not know whether it is better list all fixes?

Exclude `idioms` for E721, `has_key` for W601, `ne` for W603,
`repr` for W604, `print`, `execfile`, `raise` for not impact the test
