### PR TITLE
reindenting with a line range

### DIFF
--- a/autopep8.py
+++ b/autopep8.py
@@ -2900,11 +2900,12 @@ def apply_local_fixes(source, options):
 
     def local_fix(source, start_log, end_log,
                   start_lines, end_lines, indents, last_line):
-        """reindent the source between start_log and end_log.
+        """apply_global_fixes to the source between start_log and end_log.
 
         The subsource must be the correct syntax of a complete python program
-        (but all lines may be indented). The subsource's shared indent is
-        removed, reindent is applied and the indent prepended back.
+        (but all lines may share an indentation). The subsource's shared indent is
+        removed, fixes are applied and the indent prepended back. Taking care to
+        not reindent strings.
 
         last_line is the strict cut off (options.line_range[1]), so that
         lines after last_line are not modified.
@@ -2919,23 +2920,29 @@ def apply_local_fixes(source, options):
         sl = slice(start_lines[start_log], end_lines[end_log] + 1)
 
         subsource = source[sl]
-        # remove indent
+        # Remove indent from subsource.
         if ind:
             for line_no in start_lines[start_log:end_log + 1]:
                 pos = line_no - start_lines[start_log]
                 subsource[pos] = subsource[pos][ind:]
 
-        # fix indentation
+        # Fix indentation of subsource.
         fixed_subsource = apply_global_fixes(''.join(subsource),
                                              options,
                                              where='local')
         fixed_subsource = fixed_subsource.splitlines(True)
 
-        # add back indent
-        if ind:
-            for i, line in enumerate(fixed_subsource):
+        # Add back indent for non multi-line strings lines.
+        msl = multiline_string_lines(''.join(fixed_subsource),
+                                     include_docstrings=False)
+        for i, line in enumerate(fixed_subsource):
+            if not i + 1 in msl:
                 fixed_subsource[i] = indent + line if line != '\n' else line
 
+        # We make a special case to look at the final line, if it's a multiline
+        # *and* the cut off is somewhere inside it, we take the fixed
+        # subset up until last_line, this assumes that the number of lines
+        # does not change in this multiline line.
         changed_lines = len(fixed_subsource)
         if (start_lines[end_log] != end_lines[end_log]
                 and end_lines[end_log] > last_line):
@@ -2960,12 +2967,12 @@ def apply_local_fixes(source, options):
     start, end = options.line_range
     start -= 1
     end -= 1
-    last_line = end  # we shouldn't modify lines after this
+    last_line = end  # We shouldn't modify lines after this cut-off.
 
     logical = _find_logical(source)
 
     if not logical[0]:
-        # just blank lines implies will become '\n' ?
+        # Just blank lines, this should imply that it will become '\n' ?
         return apply_global_fixes(source, options)
 
     start_lines, indents = zip(*logical[0])
@@ -2976,8 +2983,9 @@ def apply_local_fixes(source, options):
     start_log, start = find_ge(start_lines, start)
     end_log, end = find_le(start_lines, end)
 
-    # look behind one line, if it's indented less
-    # then we can start the game from there
+    # Look behind one line, if it's indented less than current indent
+    # then we can move to this previous line knowing that its
+    # indentation level will not be changed.
     if (start_log > 0
             and indents[start_log - 1] < indents[start_log]
             and not is_continued_stmt(source[start_log - 1])):
@@ -2994,19 +3002,19 @@ def apply_local_fixes(source, options):
         ind = indents[start_log]
         for t in itertools.takewhile(lambda t: t[1][1] >= ind,
                                      enumerate(logical[0][start_log:])):
-            N_log, N = start_log + t[0], t[1][0]
-        # start shares indent up to N
+            n_log, n = start_log + t[0], t[1][0]
+        # start shares indent up to n.
 
-        if N <= end:
-            source = local_fix(source, start_log, N_log,
+        if n <= end:
+            source = local_fix(source, start_log, n_log,
                                start_lines, end_lines,
                                indents, last_line)
-            start_log = N_log if N == end else N_log + 1
+            start_log = n_log if n == end else n_log + 1
             start = start_lines[start_log]
             continue
 
         else:
-            # look at the line after end and see if allows us to reindent
+            # Look at the line after end and see if allows us to reindent.
             after_end_log, after_end = find_ge(start_lines, end + 1)
 
             if indents[after_end_log] > indents[start_log]:
@@ -3015,16 +3023,16 @@ def apply_local_fixes(source, options):
 
             if (indents[after_end_log] == indents[start_log]
                     and is_continued_stmt(source[after_end])):
-                # find N, the start of the last continued statement
-                # apply fix to previous block if there is one
+                # find n, the beginning of the last continued statement
+                # Apply fix to previous block if there is one.
                 only_block = True
-                for N, N_ind in logical[0][start_log:end_log + 1][::-1]:
-                    if N_ind == ind and not is_continued_stmt(source[N]):
-                        N_log = start_lines.index(N)
-                        source = local_fix(source, start_log, N_log - 1,
+                for n, n_ind in logical[0][start_log:end_log + 1][::-1]:
+                    if n_ind == ind and not is_continued_stmt(source[n]):
+                        n_log = start_lines.index(n)
+                        source = local_fix(source, start_log, n_log - 1,
                                            start_lines, end_lines,
                                            indents, last_line)
-                        start_log = N_log + 1
+                        start_log = n_log + 1
                         start = start_lines[start_log]
                         only_block = False
                         break

--- a/test/test_autopep8.py
+++ b/test/test_autopep8.py
@@ -3796,98 +3796,123 @@ correct = 'good syntax ?' in dict()
         with autopep8_context(line, options=['--range', '2', '2']) as result:
             self.assertEqual(fixed, result)
 
-    def test_range_line_number_changes(self):
+    def test_range_line_number_changes_from_one_line(self):
         line = 'a=12\na=1; b=2;c=3\nd=4;\n\ndef f(a = 1):\n    pass\n'
         fixed = 'a=12\na = 1\nb = 2\nc = 3\nd=4;\n\ndef f(a = 1):\n    pass\n'
         with autopep8_context(line, options=['--range', '2', '2']) as result:
             self.assertEqual(fixed, result)
 
-    def test_range_indent_changes(self):
+    def test_range_indent_changes_large_range(self):
         line = '\nif True:\n  (1, \n    2,\n3)\nelif False:\n  a = 1\nelse:\n  a = 2\n\nc = 1\nif True:\n  c = 2\n  a = (1,\n2)\n'
         fixed0_9 = '\nif True:\n    (1,\n     2,\n     3)\nelif False:\n    a = 1\nelse:\n    a = 2\n\nc = 1\nif True:\n  c = 2\n  a = (1,\n2)\n'
         with autopep8_context(line, options=['--range', '0', '9']) as result:
             self.assertEqual(fixed0_9, result)
 
+    def test_range_indent_changes_small_range(self):
+        line = '\nif True:\n  (1, \n    2,\n3)\nelif False:\n  a = 1\nelse:\n  a = 2\n\nc = 1\nif True:\n  c = 2\n  a = (1,\n2)\n'
         fixed2_5 = '\nif True:\n  (1,\n   2,\n   3)\nelif False:\n  a = 1\nelse:\n  a = 2\n\nc = 1\nif True:\n  c = 2\n  a = (1,\n2)\n'
         with autopep8_context(line, options=['--range', '2', '5']) as result:
             self.assertEqual(fixed2_5, result)
 
+    def test_range_indent_changes_multiline(self):
+        line = '\nif True:\n  (1, \n    2,\n3)\nelif False:\n  a = 1\nelse:\n  a = 2\n\nc = 1\nif True:\n  c = 2\n  a = (1,\n2)\n'
         fixed_11_15 = '\nif True:\n  (1, \n    2,\n3)\nelif False:\n  a = 1\nelse:\n  a = 2\n\nc = 1\nif True:\n    c = 2\n    a = (1,\n         2)\n'
         with autopep8_context(line, options=['--range', '11', '15']) as result:
             self.assertEqual(fixed_11_15, result)
 
+    def test_range_indent_changes_partial_multiline(self):
+        line = '\nif True:\n  (1, \n    2,\n3)\nelif False:\n  a = 1\nelse:\n  a = 2\n\nc = 1\nif True:\n  c = 2\n  a = (1,\n2)\n'
         fixed_11_14 = '\nif True:\n  (1, \n    2,\n3)\nelif False:\n  a = 1\nelse:\n  a = 2\n\nc = 1\nif True:\n    c = 2\n    a = (1,\n2)\n'
         with autopep8_context(line, options=['--range', '11', '14']) as result:
             self.assertEqual(fixed_11_14, result)
 
-        # last line in the middle of a multi-line line
+    def test_range_indent_long_multiline_small_range(self):
         line = '\nif True:\n  (1,\n2,\n3,\n\n4,\n\n5,\n6)'
-
         fixed_2_3 = '\nif True:\n    (1,\n2,\n3,\n\n4,\n\n5,\n6)\n'
         with autopep8_context(line, options=['--range', '2', '3']) as result:
             self.assertEqual(fixed_2_3, result)
 
+    def test_range_indent_long_multiline_partial_range(self):
+        line = '\nif True:\n  (1,\n2,\n3,\n\n4,\n\n5,\n6)'
         fixed_2_6 = '\nif True:\n    (1,\n     2,\n     3,\n\n4,\n\n5,\n6)\n'
         with autopep8_context(line, options=['--range', '2', '6']) as result:
             self.assertEqual(fixed_2_6, result)
 
+    def test_range_indent_long_multiline_middle_of_multiline(self):
+        line = '\nif True:\n  (1,\n2,\n3,\n\n4,\n\n5,\n6)'
         # weird-ish edge case, fixes earlier lines (up to beginning of
         # multi-line block)
         fixed_2_6 = '\nif True:\n    (1,\n     2,\n     3,\n\n     4,\n\n5,\n6)\n'
         with autopep8_context(line, options=['--range', '4', '6']) as result:
             self.assertEqual(fixed_2_6, result)
 
-        # deeper if and else blocks
+    def test_range_indent_deep_if_blocks_first_block(self):
         line = '\nif a:\n  if a = 1:\n    b = 1\n  else:\n    b = 2\nelif a == 0:\n  b = 3\nelse:\n  b = 4\n'
         with autopep8_context(line, options=['--range', '2', '5']) as result:
             self.assertEqual(line, result)
 
+    def test_range_indent_deep_if_blocks_large_range(self):
+        line = '\nif a:\n  if a = 1:\n    b = 1\n  else:\n    b = 2\nelif a == 0:\n  b = 3\nelse:\n  b = 4\n'
         fixed_2_7 = '\nif a:\n  if a = 1:\n      b = 1\n  else:\n      b = 2\nelif a == 0:\n  b = 3\nelse:\n  b = 4\n'
         with autopep8_context(line, options=['--range', '2', '7']) as result:
             self.assertEqual(fixed_2_7, result)
 
+    def test_range_indent_deep_if_blocks_second_block(self):
+        line = '\nif a:\n  if a = 1:\n    b = 1\n  else:\n    b = 2\nelif a == 0:\n  b = 3\nelse:\n  b = 4\n'
         with autopep8_context(line, options=['--range', '6', '9']) as result:
             self.assertEqual(line, result)
 
-        # some other continued statements
+    def test_range_indent_continued_statements(self):
         line = '\nif a == 1:\n\ttry:\n\t  foo\n\texcept AttributeError:\n\t  pass\n\telse:\n\t  "nooo"\n\tb = 1\n'
-
         fixed_2_8 = '\nif a == 1:\n\ttry:\n\t    foo\n\texcept AttributeError:\n\t    pass\n\telse:\n\t    "nooo"\n\tb = 1\n'
         with autopep8_context(line, options=['--range', '2', '8']) as result:
             self.assertEqual(fixed_2_8, result)
 
+    def test_range_indent_continued_statements_partial(self):
+        line = '\nif a == 1:\n\ttry:\n\t  foo\n\texcept AttributeError:\n\t  pass\n\telse:\n\t  "nooo"\n\tb = 1\n'
         with autopep8_context(line, options=['--range', '2', '6']) as result:
             self.assertEqual(line, result)
 
+    def test_range_indent_continued_statements_last_block(self):
+        line = '\nif a == 1:\n\ttry:\n\t  foo\n\texcept AttributeError:\n\t  pass\n\telse:\n\t  "nooo"\n\tb = 1\n'
         with autopep8_context(line, options=['--range', '6', '9']) as result:
             self.assertEqual(line, result)
 
-        # mutually exlusive neighbouring blocks
+    def test_range_indent_neighbouring_blocks(self):
         line = '\nif a == 1:\n  b = 1\nif a == 2:\n  b = 2\nif a == 3:\n  b = 3\n'
         fixed_2_3 = '\nif a == 1:\n    b = 1\nif a == 2:\n  b = 2\nif a == 3:\n  b = 3\n'
         with autopep8_context(line, options=['--range', '2', '3']) as result:
             self.assertEqual(fixed_2_3, result)
 
+    def test_range_indent_neighbouring_blocks_one_line(self):
+        line = '\nif a == 1:\n  b = 1\nif a == 2:\n  b = 2\nif a == 3:\n  b = 3\n'
+        fixed_2_3 = '\nif a == 1:\n    b = 1\nif a == 2:\n  b = 2\nif a == 3:\n  b = 3\n'
         fixed_3_3 = fixed_2_3
         with autopep8_context(line, options=['--range', '3', '3']) as result:
             self.assertEqual(fixed_3_3, result)
 
-        # lines above are less indented
+    def test_range_indent_above_less_indented(self):
         line = '\ndef f(x):\n  if x:\n    return x\n'
-
         fixed_3_4 = '\ndef f(x):\n    if x:\n        return x\n'
         with autopep8_context(line, options=['--range', '3', '4']) as result:
             self.assertEqual(fixed_3_4, result)
 
-        # comments and docstring
-        line = '\ndef f(x):\n  """docstring\ndocstring"""\n  #comment\n  if x:\n    return x\n'
-
+    def test_range_indent_docstrings_partial(self):
+        line = '\ndef f(x):\n  """docstring\n  docstring"""\n  #comment\n  if x:\n    return x\n'
         # TODO this should fix the comment spacing
-        fixed_2_5 = '\ndef f(x):\n  """docstring\ndocstring"""\n  #comment\n  if x:\n    return x\n'
+        fixed_2_5 = '\ndef f(x):\n  """docstring\n  docstring"""\n  #comment\n  if x:\n    return x\n'
         with autopep8_context(line, options=['--range', '2', '5']) as result:
             self.assertEqual(fixed_2_5, result)
 
-        fixed_2_7 = '\ndef f(x):\n    """docstring\n  docstring"""\n    # comment\n    if x:\n        return x\n'
+    def test_range_indent_docstrings(self):
+        line = '\ndef f(x):\n  """docstring\n  docstring"""\n  #comment\n  if x:\n    return x\n'
+        fixed_2_7 = '\ndef f(x):\n    """docstring\n    docstring"""\n    # comment\n    if x:\n        return x\n'
+        with autopep8_context(line, options=['--range', '2', '7']) as result:
+            self.assertEqual(fixed_2_7, result)
+
+    def test_range_indent_multiline_strings(self):
+        line = '\nif True:\n  a = """multi\nline\nstring"""\n  #comment\n  a=1\na=2\n'
+        fixed_2_7 = '\nif True:\n    a = """multi\nline\nstring"""\n    # comment\n    a = 1\na=2\n'
         with autopep8_context(line, options=['--range', '2', '7']) as result:
             self.assertEqual(fixed_2_7, result)
 


### PR DESCRIPTION
fixes #133, cc @myint.

Reindent (safely) a line range as much as possible.

It does a quick look behind, and a more complicated look forward around the line range to reindent as best we can _only_ within the line range. The general idea is to use the already existing reindent function on blocks which share an indentation level (remove the current indent, apply the reindent function, adds back the indent).

Happy to take comments, add some more test cases, refactor/restyle, or put this behind an option (i.e. make it not the default).

_(Perhaps one approach to increase confidence that this is working correctly is to apply autopep8 with random line ranges to a bad-pep8 python file with high coverage, and check it still passes tests... ?)_
