### PR TITLE
Fixed issue where the encoding was not correct when the contents of the ...

### DIFF
--- a/autopep8.py
+++ b/autopep8.py
@@ -2815,13 +2815,13 @@ def code_match(code, select, ignore):
     return True
 
 
-def fix_code(source, options=None):
+def fix_code(source, options=None, encoding=None):
     """Return fixed source code."""
     if not options:
         options = parse_args([''])
 
     if not isinstance(source, unicode):
-        source = source.decode(locale.getpreferredencoding())
+        source = source.decode(encoding or locale.getpreferredencoding())
 
     sio = io.StringIO(source)
     return fix_lines(sio.readlines(), options=options)
@@ -3623,7 +3623,8 @@ def main():
 
             # LineEndingWrapper is unnecessary here due to the symmetry between
             # standard in and standard out.
-            sys.stdout.write(fix_code(sys.stdin.read(), args))
+
+            sys.stdout.write(fix_code(sys.stdin.read(), args, encoding=sys.stdin.encoding))
         else:
             if args.in_place or args.diff:
                 args.files = list(set(args.files))


### PR DESCRIPTION
...file were passed directly as a stream (and PYTHONIOENCODING was properly set).

This issue was found in the autopep8.py integration into PyDev (https://sw-brainwy.rhcloud.com/tracker/PyDev/402) -- PyDev wasn't passing the PYTHONIOENCODING encoding to match the file, but even after passing it autopep8.py still gave garbled results back because it always used the locale encoding and not the one to match the file (with this patch, integrators must make sure that PYTHONIOENCODING is properly set so that stdin/stdout have the proper encoding set).
