### PR TITLE
fix current working directory issue.

### DIFF
--- a/autopep8.py
+++ b/autopep8.py
@@ -2881,7 +2881,10 @@ def fix_file(filename, options=None, output=None):
     if output:
         output = LineEndingWrapper(wrap_output(output, encoding=encoding))
 
+    oldcwd = os.getcwd()
+    os.chdir(os.path.dirname(filename))
     fixed_source = fix_lines(fixed_source, options, filename=filename)
+    os.chdir(oldcwd)
 
     if options.diff:
         new = io.StringIO(fixed_source)


### PR DESCRIPTION
lib2to3's import fixer assumes the source code given to it is under
current working directory, so we have to cd to the correct directory
first and cd back later.
