### PR TITLE
set DEFAULT_INDENT_SIZE to what was passed in command line arguments

### DIFF
--- a/autopep8.py
+++ b/autopep8.py
@@ -3618,6 +3618,9 @@ def main():
     try:
         args = parse_args(sys.argv[1:])
 
+        global DEFAULT_INDENT_SIZE
+        DEFAULT_INDENT_SIZE = args.indent_size
+
         if args.list_fixes:
             for code, description in sorted(supported_fixes()):
                 print('{code} - {description}'.format(


### PR DESCRIPTION
The original code wasn't adjusting DEFAULT_INDENT_SIZE based on what was passed in the arguments, which resulted in getting a lot of hanging indent errors for me, when using an indent size that isn't 4. This adjusts the DEFAULT_INDENT_SIZE variable to whatever the used passed in the arguments.
