### PR TITLE
ENH add --global-config and --ignore-local-config arguments

### DIFF
--- a/autopep8.py
+++ b/autopep8.py
@@ -3689,7 +3689,7 @@ def wrap_output(output, encoding):
                                       else output)
 
 
-def main(apply_config=False):
+def main(apply_config=True):
     """Tool main."""
     try:
         # Exit on broken pipe.
@@ -3754,9 +3754,5 @@ _cached_tokenizer = CachedTokenizer()
 generate_tokens = _cached_tokenizer.generate_tokens
 
 
-def _main(apply_config=True):
-    return main(apply_config=apply_config)
-
-
 if __name__ == '__main__':
-    sys.exit(_main())
+    sys.exit(main())

--- a/setup.py
+++ b/setup.py
@@ -57,5 +57,5 @@ with io.open('README.rst') as readme:
         test_suite='test.test_autopep8',
         py_modules=['autopep8'],
         zip_safe=False,
-        entry_points={'console_scripts': ['autopep8 = autopep8:_main']},
+        entry_points={'console_scripts': ['autopep8 = autopep8:main']},
     )

--- a/test/test_autopep8.py
+++ b/test/test_autopep8.py
@@ -969,7 +969,7 @@ try:
         # elsewhere is in a multiline string. If we don't filter the innocuous
         # report properly, the below command will take a long time.
         p = Popen(list(AUTOPEP8_CMD_TUPLE) +
-                  ['-vvv', '--select=E101', '--diff',
+                  ['-vvv', '--select=E101', '--diff', '--global-config=/dev/null',
                    os.path.join(ROOT_DIR, 'test', 'e101_example.py')],
                   stdout=PIPE, stderr=PIPE)
         output = [x.decode('utf-8') for x in p.communicate()][0]
@@ -4624,8 +4624,8 @@ class ParseArgsTests(unittest.TestCase):
     def skip_if_global_default(self):
         # Note: this will fail if DEFAULT_CONFIG is populated...
         if os.path.isfile(autopep8.DEFAULT_CONFIG):
-            raise SkipTest("Can't test without DEFAULT_CONFIG as "
-                           "found %s" % autopep8.DEFAULT_CONFIG)
+            raise unittest.SkipTest("Can't test without DEFAULT_CONFIG as "
+                                    "found %s" % autopep8.DEFAULT_CONFIG)
 
 
 class ExperimentalSystemTests(unittest.TestCase):


### PR DESCRIPTION
fixes #129.

EDIT: behaviour changed, see [comments below](https://github.com/hhatto/autopep8/pull/167#issuecomment-56284739).

~~By default autopep8 looks up config files:~~
- ~~First locally (in current dir) then the parent dir etc. if not found it uses from the DEFAULT_CONFIG file.~~
- ~~If you pass it a specific file it just uses that.~~
- ~~If you pass False, i.e. something which isn't a file, it just uses the standard defaults.~~
- ~~Any arguments you pass in overide defaults/configs.~~

Note: When I say "uses", I mean that values are updated over the standard defaults.

It's straightforward to tweak this behaviour (Note: this implementation is _basically_ straight out of [pep8radius](https://github.com/hayd/pep8radius), although that atm does something slightly different with regard to which files to use).

I think this solution is the easiest/cleanest to implement so just did it so it can be discussed/changed.
