### PR TITLE
enh add setup.cfg for wheels distribution

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[bdist_wheel]
+universal = 1


### PR DESCRIPTION
Allows you to push a wheel to pypi.

see http://pythonwheels.com/ (related bug on pep8radius https://github.com/hayd/pep8radius/issues/77)
