### PR TITLE
Patch to fix the case of x**2 -> x ** 2.

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -20,3 +20,4 @@ Patches
 - 小明 (https://github.com/dongweiming)
 - Andy Hayden (https://github.com/hayd)
 - Fabio Zadrozny (https://github.com/fabioz)
+- Tristan Maxson (https://github.com/tgmaxson)

--- a/autopep8.py
+++ b/autopep8.py
@@ -638,6 +638,12 @@ class FixPEP8(object):
         offset = result['column'] - 1
         fixed = target[:offset] + ' ' + target[offset:]
 
+        # Ignore the case of 'x**2'
+        if target[offset:offset+2] == '**' and result['id'] == "E226":
+            return []
+        if target[offset-2:offset] == '**' and result['id'] == "E225":
+            return []
+
         # Only proceed if non-whitespace characters match.
         # And make sure we don't break the indentation.
         if (


### PR DESCRIPTION
PEP8 specifies that x**2 should be allowed now.  This patch tries to handle the solution the best it can.  Some people might still want the ability to keep the spaces so this code does not remove them,  but in general it should not change x**2 to x *\* 2 according to current PEP8 and coding standards.
