### PR TITLE
Fix exclude in recursive mode

### DIFF
--- a/autopep8.py
+++ b/autopep8.py
@@ -3610,6 +3610,8 @@ def match_file(filename, exclude):
     for pattern in exclude:
         if fnmatch.fnmatch(base_name, pattern):
             return False
+        if fnmatch.fnmatch(filename, pattern):
+            return False
 
     if not os.path.isdir(filename) and not is_python_file(filename):
         return False

--- a/test/test_autopep8.py
+++ b/test/test_autopep8.py
@@ -428,6 +428,39 @@ sys.maxint
             self.assertTrue(autopep8.match_file(filename, exclude=[]),
                             msg=filename)
 
+    def test_find_files(self):
+        temp_directory = tempfile.mkdtemp()
+        try:
+            target = os.path.join(temp_directory, 'dir')
+            os.mkdir(target)
+            with open(os.path.join(target, 'a.py'), 'w'):
+                pass
+
+            exclude = os.path.join(target, 'ex')
+            os.mkdir(exclude)
+            with open(os.path.join(exclude, 'b.py'), 'w'):
+                pass
+
+            sub = os.path.join(exclude, 'sub')
+            os.mkdir(sub)
+            with open(os.path.join(sub, 'c.py'), 'w'):
+                pass
+
+            cwd = os.getcwd()
+            os.chdir(temp_directory)
+            try:
+                files = list(autopep8.find_files(
+                    ['dir'], True, [os.path.join('dir', 'ex')]))
+            finally:
+                os.chdir(cwd)
+
+            file_names = [os.path.basename(f) for f in files]
+            self.assertIn('a.py', file_names)
+            self.assertNotIn('b.py', file_names)
+            self.assertNotIn('c.py', file_names)
+        finally:
+            shutil.rmtree(temp_directory)
+
     def test_line_shortening_rank(self):
         self.assertGreater(
             autopep8.line_shortening_rank('(1\n+1)\n',


### PR DESCRIPTION
find_files did match files and subdirectories from excluded directory in recursive mode.

E.g. if running `autopep8 -i -r --exclude dir/excluded dir/` files from `dir/excluded/` and `dir/excluded/subdir/` were still taken in account.

BTW, there are 5 tests failing, but these are not related to my changes. I get the same failures without my commit.

```
======================================================================
FAIL: test_diff (__main__.CommandLineTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test\test_autopep8.py", line 4245, in test_diff
    self.assertEqual(fixed, '\n'.join(result.split('\n')[3:]))
AssertionError: u"-'abc'  \n+'abc'\n" != u"-'abc'  \r\n+'abc'\r\n"
- -'abc'
+ -'abc'
?         +
- +'abc'
+ +'abc'
?       +


======================================================================
FAIL: test_pep8_ignore (__main__.CommandLineTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test\test_autopep8.py", line 4272, in test_pep8_ignore
    self.assertEqual(line, result)
AssertionError: u"'abc'  \n" != u"'abc'  \r\n"
- 'abc'
+ 'abc'
?        +


======================================================================
FAIL: test_pep8_ignore_should_handle_trailing_comma_gracefully (__main__.CommandLineTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test\test_autopep8.py", line 4278, in test_pep8_ignore_should_handle_trailing_comma_gracefully
    self.assertEqual(fixed, result)
AssertionError: u"'abc'\n" != u"'abc'\r\n"
- 'abc'
+ 'abc'
?      +


======================================================================
FAIL: test_pep8_passes (__main__.CommandLineTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test\test_autopep8.py", line 4267, in test_pep8_passes
    self.assertEqual(fixed, result)
AssertionError: u"'abc'\n" != u"'abc'\r\n"
- 'abc'
+ 'abc'
?      +


======================================================================
FAIL: test_recursive (__main__.CommandLineTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test\test_autopep8.py", line 4384, in test_recursive
    '\n'.join(result.split('\n')[3:5]))
AssertionError: u"-'abc'  \n+'abc'" != u"-'abc'  \r\n+'abc'\r"
- -'abc'
+ -'abc'
?         +
?       + +'abc'


----------------------------------------------------------------------
Ran 472 tests in 23.736s

FAILED (failures=5)
```
