### PR TITLE
Fix for "dictionary changed size during iteration"

### DIFF
--- a/autopep8.py
+++ b/autopep8.py
@@ -2930,7 +2930,7 @@ def fix_file(filename, options=None, output=None, apply_config=False):
 
 def global_fixes():
     """Yield multiple (code, function) tuples."""
-    for function in globals().values():
+    for function in list(globals().values()):
         if inspect.isfunction(function):
             arguments = inspect.getargspec(function)[0]
             if arguments[:1] != ['source']:


### PR DESCRIPTION
The error I had was the one below, so, making sure we have a copy of the global values before we start iterating.

java.lang.RuntimeException: Traceback (most recent call last):
  File "X:\pydev\plugins\org.python.pydev\pysrc\third_party\pep8\autopep8.py", line 3782, in <module>
    sys.exit(main())
  File "X:\pydev\plugins\org.python.pydev\pysrc\third_party\pep8\autopep8.py", line 3742, in main
    fix_code(sys.stdin.read(), args, encoding=encoding))
  File "X:\pydev\plugins\org.python.pydev\pysrc\third_party\pep8\autopep8.py", line 2860, in fix_code
    return fix_lines(sio.readlines(), options=options)
  File "X:\pydev\plugins\org.python.pydev\pysrc\third_party\pep8\autopep8.py", line 2879, in fix_lines
    filename=filename)
  File "X:\pydev\plugins\org.python.pydev\pysrc\third_party\pep8\autopep8.py", line 2967, in apply_global_fixes
    for (code, function) in global_fixes():
  File "X:\pydev\plugins\org.python.pydev\pysrc\third_party\pep8\autopep8.py", line 2944, in global_fixes
    for function in globals().values():
RuntimeError: dictionary changed size during iteration