### PR TITLE
fix for #175

### DIFF
--- a/autopep8.py
+++ b/autopep8.py
@@ -3087,10 +3087,6 @@ def apply_local_fixes(source, options):
             if not i + 1 in msl:
                 fixed_subsource[i] = indent + line if line != '\n' else line
 
-        # Avoid buggy case. See issue #175.
-        if len(fixed_subsource) != len(subsource):
-            return source
-
         # We make a special case to look at the final line, if it's a multiline
         # *and* the cut off is somewhere inside it, we take the fixed
         # subset up until last_line, this assumes that the number of lines
@@ -3190,9 +3186,14 @@ def apply_local_fixes(source, options):
                 for n, n_ind in logical[0][start_log:end_log + 1][::-1]:
                     if n_ind == ind and not is_continued_stmt(source[n]):
                         n_log = start_lines.index(n)
-                        source = local_fix(source, start_log, n_log - 1,
-                                           start_lines, end_lines,
-                                           indents, last_line)
+                        fixed_source = local_fix(source, start_log, n_log - 1,
+                                                 start_lines, end_lines,
+                                                 indents, last_line)
+                        if len(fixed_source) == len(source):
+                            source = fixed_source
+                        else:  # see GH 175
+                            source = fixed_source
+                            break
                         start_log = n_log + 1
                         start = start_lines[start_log]
                         only_block = False

--- a/test/test_autopep8.py
+++ b/test/test_autopep8.py
@@ -4284,6 +4284,49 @@ if True:
         with autopep8_context(line, options=['--line-range', '1', '1']) as result:
             self.assertEqual(line, result)
 
+    def test_range_changes_line_count(self):
+        # GH 175
+        line = """\
+a = []
+a.sort()
+if True:
+    a = []
+    a.sort()
+else:
+    pass
+"""
+        fixed = """\
+a = sorted([])
+if True:
+    a = []
+    a.sort()
+else:
+    pass
+"""
+        with autopep8_context(line, options=['--range', '1', '5', '-a']) as result:
+            self.assertEqual(fixed, result)
+
+    def test_range_changes_line_count_twice(self):
+        # GH 175
+        line = """\
+a = []
+a.sort()
+if True:
+    a = []
+    a.sort()
+else:
+    pass
+"""
+        fixed = """\
+a = sorted([])
+if True:
+    a = sorted([])
+else:
+    pass
+"""
+        with autopep8_context(line, options=['--range', '1', '9', '-a']) as result:
+            self.assertEqual(fixed, result)
+
 
 class CommandLineTests(unittest.TestCase):
 


### PR DESCRIPTION
Ends the pass early if there in a change to the line count.

*There is probably a more efficient way (without requiring another pass).*