### PR TITLE
feature: integrate autopep8 into other python scripts easily

### DIFF
--- a/autopep8.py
+++ b/autopep8.py
@@ -3582,7 +3582,7 @@ def get_encoding():
     return locale.getpreferredencoding() or sys.getdefaultencoding()
 
 
-def main(apply_config=True):
+def main(apply_config=True, argv=sys.argv):
     """Tool main."""
     try:
         # Exit on broken pipe.
@@ -3592,7 +3592,7 @@ def main(apply_config=True):
         pass
 
     try:
-        args = parse_args(sys.argv[1:], apply_config=apply_config)
+        args = parse_args(argv[1:], apply_config=apply_config)
 
         if args.list_fixes:
             for code, description in sorted(supported_fixes()):


### PR DESCRIPTION
When running autopep8 from another python script you can now set the
arguemnts directly without having to run another python interpreter
inside a subprocess. nosetests offer the exact same interface as well.