### PR TITLE
Catch out of memory exceptions when opening large files.

### DIFF
--- a/autopep8.py
+++ b/autopep8.py
@@ -3563,7 +3563,7 @@ def is_python_file(filename):
     try:
         with open_with_encoding(filename) as f:
             first_line = f.readlines(1)[0]
-    except (IOError, IndexError):
+    except (IOError, IndexError, MemoryError):
         return False
 
     if not PYTHON_SHEBANG_REGEX.match(first_line):


### PR DESCRIPTION
When running in a folder with large data files around, the `open_with_encoding()` function tries to read too much and runs out of memory.

Command line: `autopep8 -r -i .`