### PR TITLE
Revert "E301 has been further split into E305, E306"

### DIFF
--- a/autopep8.py
+++ b/autopep8.py
@@ -460,8 +460,6 @@ class FixPEP8(object):
         self.fix_e273 = self.fix_e271
         self.fix_e274 = self.fix_e271
         self.fix_e309 = self.fix_e301
-        self.fix_e305 = self.fix_e301
-        self.fix_e306 = self.fix_e301
         self.fix_e501 = (
             self.fix_long_line_logically if
             options and (options.aggressive >= 2 or options.experimental) else


### PR DESCRIPTION
Reverts hhatto/autopep8#283. It seems to be causing failures.