### PR TITLE
Add basic support for pycodestyle configuration

### DIFF
--- a/autopep8.py
+++ b/autopep8.py
@@ -3289,8 +3289,15 @@ def read_config(args, parser):
                     break
                 (parent, tail) = os.path.split(parent)
 
-        defaults = dict((k.lstrip('-').replace('-', '_'), v)
-                        for k, v in config.items('pep8'))
+        defaults = dict()
+
+        for section in ['pep8', 'pycodestyle']:
+            if config.has_section(section):
+                defaults.update(dict(
+                    (k.lstrip('-').replace('-', '_'), v)
+                    for k, v in config.items(section)
+                ))
+
         parser.set_defaults(**defaults)
     except Error:
         # Ignore for now.

--- a/test/fake_pycodestyle_configuration/tox.ini
+++ b/test/fake_pycodestyle_configuration/tox.ini
@@ -1,0 +1,2 @@
+[pycodestyle]
+max-line-length = 40

--- a/test/test_autopep8.py
+++ b/test/test_autopep8.py
@@ -42,7 +42,9 @@ import autopep8
 
 
 FAKE_CONFIGURATION = os.path.join(ROOT_DIR, 'test', 'fake_configuration')
-
+FAKE_PYCODESTYLE_CONFIGURATION = os.path.join(
+    ROOT_DIR, 'test', 'fake_pycodestyle_configuration'
+)
 
 if 'AUTOPEP8_COVERAGE' in os.environ and int(os.environ['AUTOPEP8_COVERAGE']):
     AUTOPEP8_CMD_TUPLE = ('coverage', 'run', '--branch', '--parallel',
@@ -4631,6 +4633,13 @@ class ConfigurationTests(unittest.TestCase):
             apply_config=True)
         self.assertEqual(args.global_config, 'False')
         self.assertEqual(args.indent_size, 2)
+
+    def test_local_pycodestyle_config_line_length(self):
+        args = autopep8.parse_args(
+            [os.path.join(FAKE_PYCODESTYLE_CONFIGURATION, 'foo.py'),
+             '--global-config={0}'.format(os.devnull)],
+            apply_config=True)
+        self.assertEqual(args.max_line_length, 40)
 
     def test_config_false_with_local_autocomplete(self):
         args = autopep8.parse_args(


### PR DESCRIPTION
PEP8 has been officially renamed to pycodestyle (as I'm sure you're aware!)

The recommendation is to now include ` [pycodestyle]` section within a configuration file. This adds support for `[pycodestyle]` blocks whilst maintaining compatibility with `[pep8]`.