### PR TITLE
removed code for fixing E309 and all the tests

### DIFF
--- a/autopep8.py
+++ b/autopep8.py
@@ -459,7 +459,6 @@ class FixPEP8(object):
         self.fix_e272 = self.fix_e271
         self.fix_e273 = self.fix_e271
         self.fix_e274 = self.fix_e271
-        self.fix_e309 = self.fix_e301
         self.fix_e501 = (
             self.fix_long_line_logically if
             options and (options.aggressive >= 2 or options.experimental) else

--- a/test/suite/out/E10.py
+++ b/test/suite/out/E10.py
@@ -19,7 +19,6 @@ p4change = {
 
 
 class TestP4Poller(unittest.TestCase):
-
     def setUp(self):
         self.setUpGetProcessOutput()
         return self.setUpChangeSource()

--- a/test/test_autopep8.py
+++ b/test/test_autopep8.py
@@ -2212,32 +2212,6 @@ def foo():
         with autopep8_context(line) as result:
             self.assertEqual(fixed, result)
 
-    def test_e309(self):
-        line = """
-class Foo:
-    def bar():
-        print 1
-"""
-        fixed = """
-class Foo:
-
-    def bar():
-        print 1
-"""
-        with autopep8_context(line) as result:
-            self.assertEqual(fixed, result)
-
-    def test_not_e309_with_comment(self):
-        line = """
-class Foo:
-
-    # A comment.
-    def bar():
-        print 1
-"""
-        with autopep8_context(line) as result:
-            self.assertEqual(line, result)
-
     def test_e401(self):
         line = 'import os, sys\n'
         fixed = 'import os\nimport sys\n'


### PR DESCRIPTION
As mentions in #194, E309 is not in PEP8 and should not be fixed by autopep8.

I took the liberty to remove the code and and related tests. Tested with Python version 2.7.10 and 3.5.1 and pycodestyle version 2.2.0