### PR TITLE
improved performance when exec very long line

### DIFF
--- a/autopep8.py
+++ b/autopep8.py
@@ -680,7 +680,8 @@ class FixPEP8(object):
                 return
             if not check_syntax(fixed.lstrip()):
                 return
-            re = [e for e in pycodestyle.missing_whitespace_around_operator(fixed, ts)]
+            re = [e for e in pycodestyle.missing_whitespace_around_operator(
+                  fixed, ts)]
             re.reverse()
             for e in re:
                 if error_code != e[1].split()[0]:

--- a/autopep8.py
+++ b/autopep8.py
@@ -673,6 +673,21 @@ class FixPEP8(object):
             _get_indentation(fixed) == _get_indentation(target)
         ):
             self.source[result['line'] - 1] = fixed
+            error_code = result.get('id', 0)
+            try:
+                ts = generate_tokens(fixed)
+            except tokenize.TokenError:
+                return
+            if not check_syntax(fixed.lstrip()):
+                return
+            re = [e for e in pycodestyle.missing_whitespace_around_operator(fixed, ts)]
+            re.reverse()
+            for e in re:
+                if error_code != e[1].split()[0]:
+                    continue
+                offset = e[0][1]
+                fixed = fixed[:offset] + ' ' + fixed[offset:]
+            self.source[result['line'] - 1] = fixed
         else:
             return []
 


### PR DESCRIPTION
for #177 #318 

target file:

```
$ cat ~/very-long-line.py
def getHexVolume3(x,y,z):
    v=-x[0]*y[3]*z[4]+x[0]*y[4]*z[3]-x[1]*y[3]*z[0]+x[1]*y[0]*z[3]+x[1]*y[4]*z[0]-x[1]*y[0]*z[4]-y[0]*z[3]*x[4]+y[0]*x[3]*z[4]-y[1]*z[3]*x[0]+y[1]*x[0]*z[4]+y[1]*x[3]*z[0]-z[0]*x[3]*y[4]+z[0]*y[3]*x[4]-z[1]*x[3]*y[0]+z[1]*y[0]*x[4]+z[1]*y[3]*x[0]-x[1]*y[2]*z[0]+x[1]*y[2]*z[5]+x[1]*y[0]*z[2]+x[1]*y[5]*z[0]-x[1]*y[5]*z[2]-x[1]*y[0]*z[5]-y[1]*z[0]*x[5]-y[1]*z[2]*x[0]+y[1]*z[2]*x[5]+y[1]*x[0]*z[5]+y[1]*x[2]*z[0]-y[1]*x[2]*z[5]-z[1]*x[0]*y[5]-z[1]*x[2]*y[0]+z[1]*x[2]*y[5]+z[1]*y[0]*x[5]+z[1]*y[2]*x[0]-z[1]*y[2]*x[5]-y[1]*z[0]*x[4]-z[1]*x[0]*y[4]-x[0]*y[3]*z[7]+x[0]*y[7]*z[3]+x[2]*y[3]*z[7]-x[2]*y[7]*z[3]-x[2]*y[3]*z[0]+x[2]*y[0]*z[3]-y[0]*z[3]*x[7]+y[0]*x[3]*z[7]-y[2]*z[3]*x[0]+y[2]*x[3]*z[0]+y[2]*z[3]*x[7]-y[2]*x[3]*z[7]+z[2]*x[3]*y[7]-z[0]*x[3]*y[7]+z[0]*y[3]*x[7]-z[2]*y[3]*x[7]-z[2]*x[3]*y[0]+z[2]*y[3]*x[0]-x[1]*y[6]*z[2]+x[1]*y[2]*z[6]-x[2]*y[6]*z[3]+x[2]*y[3]*z[6]-x[2]*y[3]*z[1]+x[2]*y[1]*z[3]-z[1]*y[2]*x[6]-z[2]*x[3]*y[1]+z[2]*y[3]*x[1]+z[2]*x[3]*y[6]-z[2]*y[3]*x[6]+y[2]*z[3]*x[6]-y[2]*z[3]*x[1]+y[2]*x[3]*z[1]-y[2]*x[3]*z[6]+z[1]*x[2]*y[6]+y[1]*z[2]*x[6]-y[1]*x[2]*z[6]-x[0]*y[7]*z[4]+x[0]*y[4]*z[7]+x[5]*y[7]*z[4]-x[5]*y[4]*z[7]-x[5]*y[0]*z[4]+x[1]*y[6]*z[5]-x[1]*y[5]*z[6]+z[1]*x[6]*y[5]-z[1]*y[6]*x[5]-z[5]*x[1]*y[4]+z[5]*y[1]*x[4]+z[5]*x[6]*y[4]-z[5]*y[6]*x[4]-y[5]*z[1]*x[4]+y[5]*z[6]*x[4]+y[5]*x[1]*z[4]-y[5]*x[6]*z[4]-x[5]*y[1]*z[4]+x[5]*y[4]*z[1]+y[1]*z[6]*x[5]-y[1]*x[6]*z[5]-x[6]*y[2]*z[5]+x[6]*y[5]*z[2]-x[6]*y[7]*z[2]-x[6]*y[5]*z[7]+x[6]*y[2]*z[7]+x[6]*y[7]*z[5]-x[2]*y[5]*z[6]+x[7]*y[3]*z[4]-x[7]*y[4]*z[3]+y[6]*z[3]*x[7]+y[6]*z[7]*x[4]-y[6]*x[3]*z[7]-y[6]*x[7]*z[4]-x[3]*y[7]*z[4]+x[3]*y[4]*z[7]-x[4]*y[3]*z[7]+x[4]*y[7]*z[3]+x[6]*y[3]*z[7]+x[6]*y[7]*z[4]-x[6]*y[4]*z[7]-x[6]*y[7]*z[3]+z[6]*x[3]*y[7]+z[6]*x[7]*y[4]-z[6]*y[3]*x[7]-z[6]*y[7]*x[4]+x[2]*y[6]*z[5]+z[6]*x[2]*y[7]+z[6]*x[7]*y[5]-z[6]*y[2]*x[7]-z[6]*y[7]*x[5]-x[5]*y[6]*z[2]+x[5]*y[2]*z[6]+y[6]*z[2]*x[7]+y[6]*z[7]*x[5]-y[6]*x[2]*z[7]-y[6]*x[7]*z[5]+x[5]*y[4]*z[0]-y[0]*z[7]*x[4]+y[0]*x[7]*z[4]-y[5]*z[0]*x[4]+y[5]*x[0]*z[4]+y[5]*z[7]*x[4]-y[5]*x[7]*z[4]-z[0]*x[7]*y[4]+z[0]*y[7]*x[4]+z[5]*x[7]*y[4]-z[5]*y[7]*x[4]-z[5]*x[0]*y[4]+z[5]*y[0]*x[4]+x[5]*y[6]*z[4]-x[5]*y[4]*z[6]

    v=v/12
    return v
```

before:
```
$ time python autopep8.py -aa --ignore=E501 ~/very-long-line.py
def getHexVolume3(x, y, z):
    v = -x[0] * y[3] * z[4] + x[0] * y[4] * z[3] - x[1] * y[3] * z[0] + x[1] * y[0] * z[3] + x[1] * y[4] * z[0] - x[1] * y[0] * z[4] - y[0] * z[3] * x[4] + y[0] * x[3] * z[4] - y[1] * z[3] * x[0] + y[1] * x[0] * z[4] + y[1] * x[3] * z[0] - z[0] * x[3] * y[4] + z[0] * y[3] * x[4] - z[1] * x[3] * y[0] + z[1] * y[0] * x[4] + z[1] * y[3] * x[0] - x[1] * y[2] * z[0] + x[1] * y[2] * z[5] + x[1] * y[0] * z[2] + x[1] * y[5] * z[0] - x[1] * y[5] * z[2] - x[1] * y[0] * z[5] - y[1] * z[0] * x[5] - y[1] * z[2] * x[0] + y[1] * z[2] * x[5] + y[1] * x[0] * z[5] + y[1] * x[2] * z[0] - y[1] * x[2] * z[5] - z[1] * x[0] * y[5] - z[1] * x[2] * y[0] + z[1] * x[2] * y[5] + z[1] * y[0] * x[5] + z[1] * y[2] * x[0] - z[1] * y[2] * x[5] - y[1] * z[0] * x[4] - z[1] * x[0] * y[4] - x[0] * y[3] * z[7] + x[0] * y[7] * z[3] + x[2] * y[3] * z[7] - x[2] * y[7] * z[3] - x[2] * y[3] * z[0] + x[2] * y[0] * z[3] - y[0] * z[3] * x[7] + y[0] * x[3] * z[7] - y[2] * z[3] * x[0] + y[2] * x[3] * z[0] + y[2] * z[3] * x[7] - y[2] * x[3] * z[7] + z[2] * x[3] * y[7] - z[0] * x[3] * y[7] + z[0] * y[3] * x[7] - z[2] * y[3] * x[7] - z[2] * x[3] * y[0] + z[2] * y[3] * x[0] - x[1] * y[6] * z[2] + x[1] * y[2] * z[6] - x[2] * y[6] * z[3] + x[2] * y[3] * z[6] - x[2] * y[3] * z[1] + x[2] * y[1] * z[3] - z[1] * y[2] * x[6] - z[2] * x[3] * y[1] + z[2] * y[3] * x[1] + z[2] * x[3] * y[6] - z[2] * y[3] * x[6] + y[2] * z[3] * x[6] - y[2] * z[3] * x[1] + y[2] * x[3] * z[1] - y[2] * x[3] * z[6] + z[1] * x[2] * y[6] + y[1] * z[2] * x[6] - y[1] * x[2] * z[6] - x[0] * y[7] * z[4] + x[0] * y[4] * z[7] + x[5] * y[7] * z[4] - x[5] * y[4] * z[7] - x[5] * y[0] * z[4] + x[1] * y[6] * z[5] - x[1] * y[5] * z[6] + z[1] * x[6] * y[5] - z[1] * y[6] * x[5] - z[5] * x[1] * y[4] + z[5] * y[1] * x[4] + z[5] * x[6] * y[4] - z[5] * y[6] * x[4] - y[5] * z[1] * x[4] + y[5] * z[6] * x[4] + y[5] * x[1] * z[4] - y[5] * x[6] * z[4] - x[5] * y[1] * z[4] + x[5] * y[4] * z[1] + y[1] * z[6] * x[5] - y[1] * x[6] * z[5] - x[6] * y[2] * z[5] + x[6] * y[5] * z[2] - x[6] * y[7] * z[2] - x[6] * y[5] * z[7] + x[6] * y[2] * z[7] + x[6] * y[7] * z[5] - x[2] * y[5] * z[6] + x[7] * y[3] * z[4] - x[7] * y[4] * z[3] + y[6] * z[3] * x[7] + y[6] * z[7] * x[4] - y[6] * x[3] * z[7] - y[6] * x[7] * z[4] - x[3] * y[7] * z[4] + x[3] * y[4] * z[7] - x[4] * y[3] * z[7] + x[4] * y[7] * z[3] + x[6] * y[3] * z[7] + x[6] * y[7] * z[4] - x[6] * y[4] * z[7] - x[6] * y[7] * z[3] + z[6] * x[3] * y[7] + z[6] * x[7] * y[4] - z[6] * y[3] * x[7] - z[6] * y[7] * x[4] + x[2] * y[6] * z[5] + z[6] * x[2] * y[7] + z[6] * x[7] * y[5] - z[6] * y[2] * x[7] - z[6] * y[7] * x[5] - x[5] * y[6] * z[2] + x[5] * y[2] * z[6] + y[6] * z[2] * x[7] + y[6] * z[7] * x[5] - y[6] * x[2] * z[7] - y[6] * x[7] * z[5] + x[5] * y[4] * z[0] - y[0] * z[7] * x[4] + y[0] * x[7] * z[4] - y[5] * z[0] * x[4] + y[5] * x[0] * z[4] + y[5] * z[7] * x[4] - y[5] * x[7] * z[4] - z[0] * x[7] * y[4] + z[0] * y[7] * x[4] + z[5] * x[7] * y[4] - z[5] * y[7] * x[4] - z[5] * x[0] * y[4] + z[5] * y[0] * x[4] + x[5] * y[6] * z[4] - x[5] * y[4] * z[6]

    v = v / 12
    return v
python autopep8.py -aa --ignore=E501 ~/very-long-line.py  98.51s user 0.95s system 96% cpu 1:43.59 total
```

after:
```
$ time python autopep8.py -aa --ignore=E501 ~/very-long-line.py
def getHexVolume3(x, y, z):
    v = -x[0] * y[3] * z[4] + x[0] * y[4] * z[3] - x[1] * y[3] * z[0] + x[1] * y[0] * z[3] + x[1] * y[4] * z[0] - x[1] * y[0] * z[4] - y[0] * z[3] * x[4] + y[0] * x[3] * z[4] - y[1] * z[3] * x[0] + y[1] * x[0] * z[4] + y[1] * x[3] * z[0] - z[0] * x[3] * y[4] + z[0] * y[3] * x[4] - z[1] * x[3] * y[0] + z[1] * y[0] * x[4] + z[1] * y[3] * x[0] - x[1] * y[2] * z[0] + x[1] * y[2] * z[5] + x[1] * y[0] * z[2] + x[1] * y[5] * z[0] - x[1] * y[5] * z[2] - x[1] * y[0] * z[5] - y[1] * z[0] * x[5] - y[1] * z[2] * x[0] + y[1] * z[2] * x[5] + y[1] * x[0] * z[5] + y[1] * x[2] * z[0] - y[1] * x[2] * z[5] - z[1] * x[0] * y[5] - z[1] * x[2] * y[0] + z[1] * x[2] * y[5] + z[1] * y[0] * x[5] + z[1] * y[2] * x[0] - z[1] * y[2] * x[5] - y[1] * z[0] * x[4] - z[1] * x[0] * y[4] - x[0] * y[3] * z[7] + x[0] * y[7] * z[3] + x[2] * y[3] * z[7] - x[2] * y[7] * z[3] - x[2] * y[3] * z[0] + x[2] * y[0] * z[3] - y[0] * z[3] * x[7] + y[0] * x[3] * z[7] - y[2] * z[3] * x[0] + y[2] * x[3] * z[0] + y[2] * z[3] * x[7] - y[2] * x[3] * z[7] + z[2] * x[3] * y[7] - z[0] * x[3] * y[7] + z[0] * y[3] * x[7] - z[2] * y[3] * x[7] - z[2] * x[3] * y[0] + z[2] * y[3] * x[0] - x[1] * y[6] * z[2] + x[1] * y[2] * z[6] - x[2] * y[6] * z[3] + x[2] * y[3] * z[6] - x[2] * y[3] * z[1] + x[2] * y[1] * z[3] - z[1] * y[2] * x[6] - z[2] * x[3] * y[1] + z[2] * y[3] * x[1] + z[2] * x[3] * y[6] - z[2] * y[3] * x[6] + y[2] * z[3] * x[6] - y[2] * z[3] * x[1] + y[2] * x[3] * z[1] - y[2] * x[3] * z[6] + z[1] * x[2] * y[6] + y[1] * z[2] * x[6] - y[1] * x[2] * z[6] - x[0] * y[7] * z[4] + x[0] * y[4] * z[7] + x[5] * y[7] * z[4] - x[5] * y[4] * z[7] - x[5] * y[0] * z[4] + x[1] * y[6] * z[5] - x[1] * y[5] * z[6] + z[1] * x[6] * y[5] - z[1] * y[6] * x[5] - z[5] * x[1] * y[4] + z[5] * y[1] * x[4] + z[5] * x[6] * y[4] - z[5] * y[6] * x[4] - y[5] * z[1] * x[4] + y[5] * z[6] * x[4] + y[5] * x[1] * z[4] - y[5] * x[6] * z[4] - x[5] * y[1] * z[4] + x[5] * y[4] * z[1] + y[1] * z[6] * x[5] - y[1] * x[6] * z[5] - x[6] * y[2] * z[5] + x[6] * y[5] * z[2] - x[6] * y[7] * z[2] - x[6] * y[5] * z[7] + x[6] * y[2] * z[7] + x[6] * y[7] * z[5] - x[2] * y[5] * z[6] + x[7] * y[3] * z[4] - x[7] * y[4] * z[3] + y[6] * z[3] * x[7] + y[6] * z[7] * x[4] - y[6] * x[3] * z[7] - y[6] * x[7] * z[4] - x[3] * y[7] * z[4] + x[3] * y[4] * z[7] - x[4] * y[3] * z[7] + x[4] * y[7] * z[3] + x[6] * y[3] * z[7] + x[6] * y[7] * z[4] - x[6] * y[4] * z[7] - x[6] * y[7] * z[3] + z[6] * x[3] * y[7] + z[6] * x[7] * y[4] - z[6] * y[3] * x[7] - z[6] * y[7] * x[4] + x[2] * y[6] * z[5] + z[6] * x[2] * y[7] + z[6] * x[7] * y[5] - z[6] * y[2] * x[7] - z[6] * y[7] * x[5] - x[5] * y[6] * z[2] + x[5] * y[2] * z[6] + y[6] * z[2] * x[7] + y[6] * z[7] * x[5] - y[6] * x[2] * z[7] - y[6] * x[7] * z[5] + x[5] * y[4] * z[0] - y[0] * z[7] * x[4] + y[0] * x[7] * z[4] - y[5] * z[0] * x[4] + y[5] * x[0] * z[4] + y[5] * z[7] * x[4] - y[5] * x[7] * z[4] - z[0] * x[7] * y[4] + z[0] * y[7] * x[4] + z[5] * x[7] * y[4] - z[5] * y[7] * x[4] - z[5] * x[0] * y[4] + z[5] * y[0] * x[4] + x[5] * y[6] * z[4] - x[5] * y[4] * z[6]

    v = v / 12
    return v
python autopep8.py -aa --ignore=E501 ~/very-long-line.py  1.07s user 0.06s system 98% cpu 1.141 total