### PR TITLE
Fix broken "pypy3" travis build target

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ python:
     # commenting "pypy3" because it's been broken on TravisCI for several months
     # using alpha target instead
     # https://github.com/travis-ci/travis-ci/issues/6277
-    - "pypy3.3-5.5-alpha" #- "pypy3" 
+    - "pypy3.3-5.5-alpha"  #- "pypy3" 
 
 env:
     - LANG=

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,9 @@ python:
     - "3.6"
     - "pypy"
     # commenting "pypy3" because it's been broken on TravisCI for several months
-    # using the beta target for pypy3.5-5.7.1 instead
+    # using alpha target instead
     # https://github.com/travis-ci/travis-ci/issues/6277
-    - "pypy3.5-5.7.1-beta" #- "pypy3" 
+    - "pypy3.3-5.5-alpha" #- "pypy3" 
 
 env:
     - LANG=

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,10 @@ python:
     - "3.5"
     - "3.6"
     - "pypy"
-    - "pypy3"
+    # commenting "pypy3" because it's been broken on TravisCI for several months
+    # using the beta target for pypy3.5-5.7.1 instead
+    # https://github.com/travis-ci/travis-ci/issues/6277
+    - "pypy3.5-5.7.1-beta" #- "pypy3" 
 
 env:
     - LANG=


### PR DESCRIPTION
Use alternative pypy3 target for travis instead of broken "pypy3"

Reference: travis-ci/travis-ci#6277

pyenv environment pulled from here: https://github.com/pyenv/pyenv/tree/master/plugins/python-build/share/python-build