### PR TITLE
Avoid a crash when shortening comments

### DIFF
--- a/autopep8.py
+++ b/autopep8.py
@@ -885,12 +885,15 @@ class FixPEP8(object):
         if cache_entry in self.long_line_ignore_cache:
             return []
 
-        if self.options.aggressive and target.lstrip().startswith('#'):
-            # Wrap commented lines.
-            return shorten_comment(
-                line=target,
-                max_line_length=self.options.max_line_length,
-                last_comment=not next_line.lstrip().startswith('#'))
+        if target.lstrip().startswith('#'):
+            if self.options.aggressive:
+                # Wrap commented lines.
+                return shorten_comment(
+                    line=target,
+                    max_line_length=self.options.max_line_length,
+                    last_comment=not next_line.lstrip().startswith('#'))
+            else:
+                return []
 
         fixed = get_fixed_long_line(
             target=target,
@@ -1148,6 +1151,7 @@ def get_fixed_long_line(target, previous_line, original,
     indent = _get_indentation(target)
     source = target[len(indent):]
     assert source.lstrip() == source
+    assert not target.lstrip().startswith('#')
 
     # Check for partial multiline.
     tokens = list(generate_tokens(source))

--- a/test/test_autopep8.py
+++ b/test/test_autopep8.py
@@ -3199,6 +3199,16 @@ class Migration(SchemaMigration):
         with autopep8_context(line, options=['-aa']) as result:
             self.assertEqual(fixed, result)
 
+    def test_e501_shorten_comment_without_aggressive(self):
+        """Do nothing without aggressive."""
+        line = """\
+def foo():
+    pass
+# --------- ----------------------------------------------------------------------
+"""
+        with autopep8_context(line) as result:
+            self.assertEqual(line, result)
+
     def test_e501_with_aggressive_and_escaped_newline(self):
         line = """\
 if True or \\


### PR DESCRIPTION
This fixes #333. The bug was introduced in 138f2811.