### PR TITLE
Fix a bug in E305

### DIFF
--- a/autopep8.py
+++ b/autopep8.py
@@ -806,6 +806,7 @@ class FixPEP8(object):
             offset -= 1
         offset += 1
         self.source[offset] = cr + self.source[offset]
+        return [1 + offset]  # Line indexed at 1.
 
     def fix_e401(self, result):
         """Put imports on separate lines."""


### PR DESCRIPTION
e6394908 was not reporting the lines it modified. This is necessary for functions that change a line other than the one specified in `results['line']`. Otherwise, the various fixers mangle each other's results.

See https://github.com/hhatto/autopep8/issues/346#issuecomment-330849872.