### PR TITLE
change: use compile() with dont_inherit=True

### DIFF
--- a/autopep8.py
+++ b/autopep8.py
@@ -2880,7 +2880,7 @@ def refactor_with_2to3(source_text, fixer_names, filename=''):
 def check_syntax(code):
     """Return True if syntax is okay."""
     try:
-        return compile(code, '<string>', 'exec')
+        return compile(code, '<string>', 'exec', dont_inherit=True)
     except (SyntaxError, TypeError, UnicodeDecodeError):
         return False
 

--- a/test/test_autopep8.py
+++ b/test/test_autopep8.py
@@ -6132,6 +6132,21 @@ if True:
         with autopep8_context(line, options=['--experimental']) as result:
             self.assertEqual(fixed, result)
 
+    def test_e501_print_isnot_function(self):
+        line = """\
+
+def d():
+    print "%d%d%d%d%d%d%d%d%d%d%d%d%d%d%d%d%d" % (111, 111, 111, 111, 222, 222, 222, 222, 222, 222, 222, 222, 222, 333, 333, 333, 333)
+"""
+        fixed = """\
+
+def d():
+    print "%d%d%d%d%d%d%d%d%d%d%d%d%d%d%d%d%d" % (
+        111, 111, 111, 111, 222, 222, 222, 222, 222, 222, 222, 222, 222, 333,
+        333, 333, 333)
+"""
+        with autopep8_context(line, options=['--experimental']) as result:
+            self.assertEqual(fixed, result)
 
 @contextlib.contextmanager
 def autopep8_context(line, options=None):

--- a/test/test_autopep8.py
+++ b/test/test_autopep8.py
@@ -6132,6 +6132,7 @@ if True:
         with autopep8_context(line, options=['--experimental']) as result:
             self.assertEqual(fixed, result)
 
+    @unittest.skipIf(sys.version_info >= (3, ), 'syntax error in Python3')
     def test_e501_print_isnot_function(self):
         line = """\
 


### PR DESCRIPTION
for #331 

autopep8 is judging to syntax error now, if `print` is not function.
As a result conversion is not done.

I will change this behavior.