### PR TITLE
Remove redundant Python 2.6 code, drop 3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: python
 
 python:
     - "2.7"
-    - "3.3"
     - "3.4"
     - "3.5"
     - "3.6"
@@ -30,7 +29,7 @@ script:
     - python test/acid.py -aaa --experimental test/example.py
     - python test/acid.py -aaa --experimental test/example_with_reduce.py
 
-    - if [ "$TRAVIS_PYTHON_VERSION" == "3.3" ]; then python -m doctest -v README.rst; fi
+    - if [ "$TRAVIS_PYTHON_VERSION" == "3.6" ]; then python -m doctest -v README.rst; fi
 
     - if [[ "$TRAVIS_PYTHON_VERSION" != "pypy"* ]]; then pycodestyle autopep8.py; fi
     - if [[ "$TRAVIS_PYTHON_VERSION" != "pypy"* ]]; then pip install pyflakes; pyflakes autopep8.py; fi

--- a/README.rst
+++ b/README.rst
@@ -228,8 +228,8 @@ autopep8 fixes the following issues_ reported by pycodestyle_::
 autopep8 also fixes some issues not found by pycodestyle_.
 
 - Correct deprecated or non-idiomatic Python code (via ``lib2to3``). Use this
-  for making Python 2.6 and 2.7 code more compatible with Python 3. (This is
-  triggered if ``W690`` is enabled.)
+  for making Python 2.7 code more compatible with Python 3. (This is triggered
+  if ``W690`` is enabled.)
 - Normalize files with mixed line endings.
 - Put a blank line between a class docstring and its first method
   declaration. (Enabled with ``E301``.)
@@ -316,7 +316,7 @@ Testing
 Test cases are in ``test/test_autopep8.py``. They can be run directly via
 ``python test/test_autopep8.py`` or via tox_. The latter is useful for
 testing against multiple Python interpreters. (We currently test against
-CPython versions 2.6, 2.7, 3.3, 3.4, 3.5 and 3.6. We also test against PyPy.)
+CPython versions 2.7, 3.3, 3.4, 3.5 and 3.6. We also test against PyPy.)
 
 .. _`tox`: https://pypi.python.org/pypi/tox
 

--- a/README.rst
+++ b/README.rst
@@ -316,7 +316,7 @@ Testing
 Test cases are in ``test/test_autopep8.py``. They can be run directly via
 ``python test/test_autopep8.py`` or via tox_. The latter is useful for
 testing against multiple Python interpreters. (We currently test against
-CPython versions 2.7, 3.3, 3.4, 3.5 and 3.6. We also test against PyPy.)
+CPython versions 2.7, 3.4, 3.5 and 3.6. We also test against PyPy.)
 
 .. _`tox`: https://pypi.python.org/pypi/tox
 

--- a/autopep8.py
+++ b/autopep8.py
@@ -3470,8 +3470,8 @@ def read_config(args, parser):
                 (parent, tail) = os.path.split(parent)
 
         defaults = {}
-        option_list = dict([(o.dest, o.type or type(o.default))
-                            for o in parser._actions])
+        option_list = {o.dest: o.type or type(o.default)
+                       for o in parser._actions}
 
         for section in ['pep8', 'pycodestyle', 'flake8']:
             if not config.has_section(section):

--- a/autopep8.py
+++ b/autopep8.py
@@ -3418,14 +3418,14 @@ def parse_args(arguments, apply_config=False):
     elif not args.select:
         if args.aggressive:
             # Enable everything by default if aggressive.
-            args.select = set(['E', 'W'])
+            args.select = {'E', 'W'}
         else:
             args.ignore = _split_comma_separated(DEFAULT_IGNORE)
 
     if args.exclude:
         args.exclude = _split_comma_separated(args.exclude)
     else:
-        args.exclude = set([])
+        args.exclude = {}
 
     if args.jobs < 1:
         # Do not import multiprocessing globally in case it is not supported

--- a/autopep8.py
+++ b/autopep8.py
@@ -3469,7 +3469,7 @@ def read_config(args, parser):
                     break
                 (parent, tail) = os.path.split(parent)
 
-        defaults = dict()
+        defaults = {}
         option_list = dict([(o.dest, o.type or type(o.default))
                             for o in parser._actions])
 

--- a/autopep8.py
+++ b/autopep8.py
@@ -3502,7 +3502,7 @@ def read_config(args, parser):
 
 def _split_comma_separated(string):
     """Return a set of strings."""
-    return set(text.strip() for text in string.split(',') if text.strip())
+    return {text.strip() for text in string.split(',') if text.strip()}
 
 
 def decode_filename(filename):

--- a/autopep8.py
+++ b/autopep8.py
@@ -171,7 +171,7 @@ def extended_blank_lines(logical_line,
     """Check for missing blank lines after class declaration."""
     if previous_logical.startswith('def '):
         if blank_lines and pycodestyle.DOCSTRING_REGEX.match(logical_line):
-            yield (0, 'E303 too many blank lines ({0})'.format(blank_lines))
+            yield (0, 'E303 too many blank lines ({})'.format(blank_lines))
     elif pycodestyle.DOCSTRING_REGEX.match(previous_logical):
         # Missing blank line between class docstring and method declaration.
         if (
@@ -262,21 +262,21 @@ def continued_indentation(logical_line, tokens, indent_level, hang_closing,
             if close_bracket and indent[depth]:
                 # Closing bracket for visual indent.
                 if start[1] != indent[depth]:
-                    yield (start, 'E124 {0}'.format(indent[depth]))
+                    yield (start, 'E124 {}'.format(indent[depth]))
             elif close_bracket and not hang:
                 # closing bracket matches indentation of opening bracket's line
                 if hang_closing:
-                    yield (start, 'E133 {0}'.format(indent[depth]))
+                    yield (start, 'E133 {}'.format(indent[depth]))
             elif indent[depth] and start[1] < indent[depth]:
                 # Visual indent is broken.
-                yield (start, 'E128 {0}'.format(indent[depth]))
+                yield (start, 'E128 {}'.format(indent[depth]))
             elif (hanging_indent or
                   (indent_next and
                    rel_indent[row] == 2 * DEFAULT_INDENT_SIZE)):
                 # Hanging indent is verified.
                 if close_bracket and not hang_closing:
-                    yield (start, 'E123 {0}'.format(indent_level +
-                                                    rel_indent[open_row]))
+                    yield (start, 'E123 {}'.format(indent_level +
+                                                   rel_indent[open_row]))
                 hangs[depth] = hang
             elif visual_indent is True:
                 # Visual indent is verified.
@@ -300,7 +300,7 @@ def continued_indentation(logical_line, tokens, indent_level, hang_closing,
                     hangs[depth] = hang
                     error = ('E121', one_indented)
 
-                yield (start, '{0} {1}'.format(*error))
+                yield (start, '{} {}'.format(*error))
 
         # Look for visual indenting.
         if (
@@ -372,9 +372,9 @@ def continued_indentation(logical_line, tokens, indent_level, hang_closing,
         pos = (start[0], indent[0] + 4)
         desired_indent = indent_level + 2 * DEFAULT_INDENT_SIZE
         if visual_indent:
-            yield (pos, 'E129 {0}'.format(desired_indent))
+            yield (pos, 'E129 {}'.format(desired_indent))
         else:
-            yield (pos, 'E125 {0}'.format(desired_indent))
+            yield (pos, 'E125 {}'.format(desired_indent))
 
 
 del pycodestyle._checks['logical_line'][pycodestyle.continued_indentation]
@@ -532,14 +532,14 @@ class FixPEP8(object):
             else:
                 if self.options.verbose >= 3:
                     print(
-                        "--->  '{0}' is not defined.".format(fixed_methodname),
+                        "--->  '{}' is not defined.".format(fixed_methodname),
                         file=sys.stderr)
 
                     info = result['info'].strip()
-                    print('--->  {0}:{1}:{2}:{3}'.format(self.filename,
-                                                         result['line'],
-                                                         result['column'],
-                                                         info),
+                    print('--->  {}:{}:{}:{}'.format(self.filename,
+                                                     result['line'],
+                                                     result['column'],
+                                                     info),
                           file=sys.stderr)
 
     def fix(self):
@@ -983,7 +983,7 @@ class FixPEP8(object):
                                                             self.source)
         match = STARTSWITH_DEF_REGEX.match(target)
         if match:
-            self.source[line_index] = '{0}\n{1}{2}'.format(
+            self.source[line_index] = '{}\n{}{}'.format(
                 match.group(0),
                 _get_indentation(target) + self.indent_word,
                 target[match.end(0):].lstrip())
@@ -1064,7 +1064,7 @@ class FixPEP8(object):
         if match_notin:
             notin_pos_start = match_notin.start(1)
             notin_pos_end = match_notin.end()
-            target = '{0}{1} {2}'.format(
+            target = '{}{} {}'.format(
                 target[:notin_pos_start], 'in', target[notin_pos_end:])
 
         # fix 'not in'
@@ -1079,7 +1079,7 @@ class FixPEP8(object):
                     # revert 'in' -> 'not in'
                     pos_start = notin_pos_start + offset
                     pos_end = notin_pos_end + offset - 4     # len('not ')
-                    new_target = '{0}{1} {2}'.format(
+                    new_target = '{}{} {}'.format(
                         new_target[:pos_start], 'not in', new_target[pos_end:])
                 self.source[line_index] = new_target
 
@@ -1092,7 +1092,7 @@ class FixPEP8(object):
         if match:
             if match.group(3) == 'is':
                 pos_start = match.start(1)
-                self.source[line_index] = '{0}{1} {2} {3} {4}'.format(
+                self.source[line_index] = '{}{} {} {} {}'.format(
                     target[:pos_start], match.group(2), match.group(3),
                     match.group(1), target[match.end():])
 
@@ -1102,7 +1102,7 @@ class FixPEP8(object):
                                                             self.source)
         match = BARE_EXCEPT_REGEX.search(target)
         if match:
-            self.source[line_index] = '{0}{1}{2}'.format(
+            self.source[line_index] = '{}{}{}'.format(
                 target[:result['column'] - 1], "except BaseException:",
                 target[match.end():])
 
@@ -1113,7 +1113,7 @@ class FixPEP8(object):
         match = LAMBDA_REGEX.search(target)
         if match:
             end = match.end()
-            self.source[line_index] = '{0}def {1}({2}): return {3}'.format(
+            self.source[line_index] = '{}def {}({}): return {}'.format(
                 target[:match.start(0)], match.group(1), match.group(2),
                 target[end:].lstrip())
 
@@ -1179,17 +1179,17 @@ class FixPEP8(object):
                 old = t
             break
         i = target.index(one_string_token)
-        self.source[line_index] = '{0}{1}'.format(
+        self.source[line_index] = '{}{}'.format(
             target[:i], target[i + len(one_string_token):])
         nl = find_newline(self.source[line_index - 1:line_index])
         before_line = self.source[line_index - 1]
         bl = before_line.index(nl)
         if comment_index:
-            self.source[line_index - 1] = '{0} {1} {2}'.format(
+            self.source[line_index - 1] = '{} {} {}'.format(
                 before_line[:comment_index], one_string_token,
                 before_line[comment_index + 1:])
         else:
-            self.source[line_index - 1] = '{0} {1}{2}'.format(
+            self.source[line_index - 1] = '{} {}{}'.format(
                 before_line[:bl], one_string_token, before_line[bl:])
 
 
@@ -1449,8 +1449,8 @@ def code_to_2to3(select, ignore, where='', verbose=False):
     for code, fix in CODE_TO_2TO3.items():
         if code_match(code, select=select, ignore=ignore):
             if verbose:
-                print('--->  Applying {0} fix for {1}'.format(where,
-                                                              code.upper()),
+                print('--->  Applying {} fix for {}'.format(where,
+                                                            code.upper()),
                       file=sys.stderr)
             fixes |= set(fix)
     return fixes
@@ -3261,8 +3261,8 @@ def apply_global_fixes(source, options, where='global', filename='',
             continue
         if code_match(code, select=options.select, ignore=options.ignore):
             if options.verbose:
-                print('--->  Applying {0} fix for {1}'.format(where,
-                                                              code.upper()),
+                print('--->  Applying {} fix for {}'.format(where,
+                                                            code.upper()),
                       file=sys.stderr)
             source = function(source,
                               aggressive=options.aggressive)
@@ -3296,7 +3296,7 @@ def extract_code_from_function(function):
 
 
 def _get_package_version():
-    packages = ["pycodestyle: {0}".format(pycodestyle.__version__)]
+    packages = ["pycodestyle: {}".format(pycodestyle.__version__)]
     return ", ".join(packages)
 
 
@@ -3305,7 +3305,7 @@ def create_parser():
     parser = argparse.ArgumentParser(description=docstring_summary(__doc__),
                                      prog='autopep8')
     parser.add_argument('--version', action='version',
-                        version='%(prog)s {0} ({1})'.format(
+                        version='%(prog)s {} ({})'.format(
                             __version__, _get_package_version()))
     parser.add_argument('-v', '--verbose', action='count',
                         default=0,
@@ -3319,7 +3319,7 @@ def create_parser():
                         default=DEFAULT_CONFIG,
                         help='path to a global pep8 config file; if this file '
                              'does not exist then this is ignored '
-                             '(default: {0})'.format(DEFAULT_CONFIG))
+                             '(default: {})'.format(DEFAULT_CONFIG))
     parser.add_argument('--ignore-local-config', action='store_true',
                         help="don't look for and apply local config files; "
                              'if not passed, defaults are updated with any '
@@ -3347,7 +3347,7 @@ def create_parser():
                         'used by --ignore and --select')
     parser.add_argument('--ignore', metavar='errors', default='',
                         help='do not fix these errors/warnings '
-                             '(default: {0})'.format(DEFAULT_IGNORE))
+                             '(default: {})'.format(DEFAULT_IGNORE))
     parser.add_argument('--select', metavar='errors', default='',
                         help='fix only these errors/warnings (e.g. E4,W)')
     parser.add_argument('--max-line-length', metavar='n', default=79, type=int,
@@ -3799,7 +3799,7 @@ def find_files(filenames, recursive, exclude):
 def _fix_file(parameters):
     """Helper function for optionally running fix_file() in parallel."""
     if parameters[1].verbose:
-        print('[file:{0}]'.format(parameters[0]), file=sys.stderr)
+        print('[file:{}]'.format(parameters[0]), file=sys.stderr)
     try:
         fix_file(*parameters)
     except IOError as error:

--- a/autopep8.py
+++ b/autopep8.py
@@ -40,6 +40,7 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import argparse
 import codecs
 import collections
 import copy
@@ -3301,10 +3302,6 @@ def _get_package_version():
 
 def create_parser():
     """Return command-line parser."""
-    # Do import locally to be friendly to those who use autopep8 as a library
-    # and are supporting Python 2.6.
-    import argparse
-
     parser = argparse.ArgumentParser(description=docstring_summary(__doc__),
                                      prog='autopep8')
     parser.add_argument('--version', action='version',

--- a/autopep8.py
+++ b/autopep8.py
@@ -3145,8 +3145,8 @@ def fix_lines(source_lines, options, filename=''):
         sio = io.StringIO(tmp_source)
         contents = sio.readlines()
         results = _execute_pep8(pep8_options, contents)
-        codes = set([result['id'] for result in results
-                     if result['id'] in SELECTED_GLOBAL_FIXED_METHOD_CODES])
+        codes = {result['id'] for result in results
+                 if result['id'] in SELECTED_GLOBAL_FIXED_METHOD_CODES}
         # Apply global fixes only once (for efficiency).
         fixed_source = apply_global_fixes(tmp_source,
                                           options,

--- a/autopep8.py
+++ b/autopep8.py
@@ -3228,7 +3228,7 @@ def global_fixes():
 
 def _get_parameters(function):
     # pylint: disable=deprecated-method
-    if sys.version_info >= (3, 3):
+    if sys.version_info.major >= 3:
         # We need to match "getargspec()", which includes "self" as the first
         # value for methods.
         # https://bugs.python.org/issue17481#msg209469

--- a/setup.py
+++ b/setup.py
@@ -5,14 +5,12 @@
 
 import ast
 import io
-import sys
 
 from setuptools import setup
 
 
 INSTALL_REQUIRES = (
-    ['pycodestyle >= 2.3'] +
-    (['argparse'] if sys.version_info < (2, 7) else [])
+    ['pycodestyle >= 2.3']
 )
 
 
@@ -43,13 +41,12 @@ with io.open('README.rst') as readme:
             'Operating System :: OS Independent',
             'Programming Language :: Python',
             'Programming Language :: Python :: 2',
-            'Programming Language :: Python :: 2.6',
             'Programming Language :: Python :: 2.7',
             'Programming Language :: Python :: 3',
-            'Programming Language :: Python :: 3.2',
             'Programming Language :: Python :: 3.3',
             'Programming Language :: Python :: 3.4',
             'Programming Language :: Python :: 3.5',
+            'Programming Language :: Python :: 3.6',
             'Topic :: Software Development :: Libraries :: Python Modules',
             'Topic :: Software Development :: Quality Assurance',
         ],

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,6 @@ with io.open('README.rst') as readme:
             'Programming Language :: Python :: 2',
             'Programming Language :: Python :: 2.7',
             'Programming Language :: Python :: 3',
-            'Programming Language :: Python :: 3.3',
             'Programming Language :: Python :: 3.4',
             'Programming Language :: Python :: 3.5',
             'Programming Language :: Python :: 3.6',

--- a/test/acid.py
+++ b/test/acid.py
@@ -60,7 +60,7 @@ def run(filename, command, max_line_length=79,
         line_range = [first, random.randint(first, line_range[1])]
 
     command = (shlex.split(command) + (['--verbose'] if verbose else []) +
-               ['--max-line-length={0}'.format(max_line_length),
+               ['--max-line-length={}'.format(max_line_length),
                 '--ignore=' + ignore, filename] +
                aggressive * ['--aggressive'] +
                (['--experimental'] if experimental else []) +
@@ -122,8 +122,8 @@ def process_args():
     parser = argparse.ArgumentParser()
     parser.add_argument(
         '--command',
-        default='{0} {1}'.format(sys.executable,
-                                 os.path.join(ROOT_PATH, 'autopep8.py')),
+        default='{} {}'.format(sys.executable,
+                               os.path.join(ROOT_PATH, 'autopep8.py')),
         help='autopep8 command (default: %(default)s)')
     parser.add_argument('--ignore',
                         help='comma-separated errors to ignore',

--- a/test/example_with_reduce.py
+++ b/test/example_with_reduce.py
@@ -66,7 +66,7 @@ from os import open as os_open
 from os.path import isdir, split
 
 # Avoid try/except due to potential problems with delayed import mechanisms.
-if sys.version_info >= (3, 3) and sys.implementation.name == "cpython":
+if sys.version_info.major >= 3 and sys.implementation.name == "cpython":
     import importlib._bootstrap as importlib_bootstrap
 else:
     importlib_bootstrap = None
@@ -1292,7 +1292,7 @@ class NullProvider:
     def has_metadata(self, name):
         return self.egg_info and self._has(self._fn(self.egg_info,name))
 
-    if sys.version_info <= (3,):
+    if sys.version_info.major == 2:
         def get_metadata(self, name):
             if not self.egg_info:
                 return ""

--- a/test/example_with_reduce.py
+++ b/test/example_with_reduce.py
@@ -256,12 +256,7 @@ def get_build_platform():
     XXX Currently this is the same as ``distutils.util.get_platform()``, but it
     needs some hacks for Linux and Mac OS X.
     """
-    try:
-        # Python 2.7 or >=3.2
-        from sysconfig import get_platform
-    except ImportError:
-        from distutils.util import get_platform
-
+    from sysconfig import get_platform
     plat = get_platform()
     if sys.platform == "darwin" and not plat.startswith('macosx-'):
         try:

--- a/test/test_autopep8.py
+++ b/test/test_autopep8.py
@@ -1043,7 +1043,7 @@ try:
         # report properly, the below command will take a long time.
         p = Popen(list(AUTOPEP8_CMD_TUPLE) +
                   ['-vvv', '--select=E101', '--diff',
-                   '--global-config={0}'.format(os.devnull),
+                   '--global-config={}'.format(os.devnull),
                    os.path.join(ROOT_DIR, 'test', 'e101_example.py')],
                   stdout=PIPE, stderr=PIPE)
         output = [x.decode('utf-8') for x in p.communicate()][0]
@@ -4824,7 +4824,7 @@ class ConfigurationTests(unittest.TestCase):
     def test_local_config(self):
         args = autopep8.parse_args(
             [os.path.join(FAKE_CONFIGURATION, 'foo.py'),
-             '--global-config={0}'.format(os.devnull)],
+             '--global-config={}'.format(os.devnull)],
             apply_config=True)
         self.assertEqual(args.indent_size, 2)
 
@@ -4854,7 +4854,7 @@ class ConfigurationTests(unittest.TestCase):
     def test_local_pycodestyle_config_line_length(self):
         args = autopep8.parse_args(
             [os.path.join(FAKE_PYCODESTYLE_CONFIGURATION, 'foo.py'),
-             '--global-config={0}'.format(os.devnull)],
+             '--global-config={}'.format(os.devnull)],
             apply_config=True)
         self.assertEqual(args.max_line_length, 40)
 
@@ -4868,7 +4868,7 @@ class ConfigurationTests(unittest.TestCase):
 
     def test_config_false_without_local(self):
         args = autopep8.parse_args(['/nowhere/foo.py',
-                                    '--global-config={0}'.format(os.devnull)],
+                                    '--global-config={}'.format(os.devnull)],
                                    apply_config=True)
         self.assertEqual(args.indent_size, 4)
 
@@ -4876,7 +4876,7 @@ class ConfigurationTests(unittest.TestCase):
         with temporary_file_context('[pep8]\nindent-size=3\n') as filename:
             args = autopep8.parse_args(
                 [os.path.join(FAKE_CONFIGURATION, 'foo.py'),
-                 '--global-config={0}'.format(filename)],
+                 '--global-config={}'.format(filename)],
                 apply_config=True)
             self.assertEqual(args.indent_size, 2)
 
@@ -4884,7 +4884,7 @@ class ConfigurationTests(unittest.TestCase):
         with temporary_file_context('[pep8]\nindent-size=3\n') as filename:
             args = autopep8.parse_args(
                 [os.path.join(FAKE_CONFIGURATION, 'foo.py'),
-                 '--global-config={0}'.format(filename),
+                 '--global-config={}'.format(filename),
                  '--ignore-local-config'],
                 apply_config=True)
             self.assertEqual(args.indent_size, 3)
@@ -4892,7 +4892,7 @@ class ConfigurationTests(unittest.TestCase):
     def test_global_config_without_locals(self):
         with temporary_file_context('[pep8]\nindent-size=3\n') as filename:
             args = autopep8.parse_args(
-                ['/nowhere/foo.py', '--global-config={0}'.format(filename)],
+                ['/nowhere/foo.py', '--global-config={}'.format(filename)],
                 apply_config=True)
             self.assertEqual(args.indent_size, 3)
 
@@ -4900,7 +4900,7 @@ class ConfigurationTests(unittest.TestCase):
         with temporary_file_context('[pep8]\naggressive=1\n') as filename:
             args = autopep8.parse_args(
                 [os.path.join(FAKE_CONFIGURATION, 'foo.py'),
-                 '--global-config={0}'.format(filename)],
+                 '--global-config={}'.format(filename)],
                 apply_config=True)
             self.assertEqual(args.aggressive, 1)
 
@@ -4913,7 +4913,7 @@ aggressive=1
         with temporary_file_context(configstr) as filename:
             args = autopep8.parse_args(
                 [os.path.join(FAKE_CONFIGURATION, 'foo.py'),
-                 '--global-config={0}'.format(filename)],
+                 '--global-config={}'.format(filename)],
                 apply_config=True)
             self.assertEqual(args.aggressive, 1)
 

--- a/test/test_autopep8.py
+++ b/test/test_autopep8.py
@@ -16,11 +16,6 @@ import os
 import re
 import sys
 
-if sys.version_info < (2, 7):
-    import unittest2 as unittest
-else:
-    import unittest
-
 import contextlib
 import io
 import shutil
@@ -28,6 +23,7 @@ from subprocess import Popen, PIPE
 from tempfile import mkstemp
 import tempfile
 import tokenize
+import unittest
 import warnings
 
 try:
@@ -4263,8 +4259,6 @@ a.has_key(
         with autopep8_context(line, options=['--aggressive']) as result:
             self.assertEqual(fixed, result)
 
-    @unittest.skipIf(sys.version_info < (2, 6, 4),
-                     'older versions of 2.6 may be buggy')
     def test_w601_with_non_ascii(self):
         line = """\
 # -*- coding: utf-8 -*-
@@ -6191,6 +6185,7 @@ def d():
 """
         with autopep8_context(line, options=['--experimental']) as result:
             self.assertEqual(fixed, result)
+
 
 @contextlib.contextmanager
 def autopep8_context(line, options=None):

--- a/test/test_autopep8.py
+++ b/test/test_autopep8.py
@@ -6167,7 +6167,7 @@ if True:
         with autopep8_context(line, options=['--experimental']) as result:
             self.assertEqual(fixed, result)
 
-    @unittest.skipIf(sys.version_info >= (3, ), 'syntax error in Python3')
+    @unittest.skipIf(sys.version_info.major >= 3, 'syntax error in Python3')
     def test_e501_print_isnot_function(self):
         line = """\
 

--- a/test/test_autopep8.py
+++ b/test/test_autopep8.py
@@ -5673,8 +5673,6 @@ def f(self):
         with autopep8_context(line, options=['--experimental']) as result:
             self.assertEqual(fixed, result)
 
-    @unittest.skipIf(sys.version_info < (2, 7),
-                     'Python 2.6 does not support dictionary comprehensions')
     def test_e501_experimental_with_complex_reformat(self):
         line = """\
 bork(111, 111, 111, 111, 222, 222, 222, { 'foo': 222, 'qux': 222 }, ((['hello', 'world'], ['yo', 'stella', "how's", 'it'], ['going']), {str(i): i for i in range(10)}, {'bork':((x, x**x) for x in range(10))}), 222, 222, 222, 222, 333, 333, 333, 333)

--- a/test/vim_autopep8.py
+++ b/test/vim_autopep8.py
@@ -17,14 +17,14 @@ ENCODING = vim.eval('&fileencoding')
 
 
 def encode(text):
-    if sys.version_info[0] >= 3:
+    if sys.version_info.major >= 3:
         return text
     else:
         return text.encode(ENCODING)
 
 
 def decode(text):
-    if sys.version_info[0] >= 3:
+    if sys.version_info.major >= 3:
         return text
     else:
         return text.decode(ENCODING)

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=py27,py33,py34,py35,py36
+envlist=py27,py34,py35,py36
 
 [testenv]
 commands=

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=py26,py27,py32,py33,py34,py35
+envlist=py27,py33,py34,py35,py36
 
 [testenv]
 commands=
@@ -7,12 +7,5 @@ commands=
     python test/acid.py --aggressive test/example.py
     python test/acid.py --compare-bytecode test/example.py
 deps=
-    pycodestyle>=2.0
-    pydiff>=0.1.2
-
-[testenv:py26]
-deps=
-    argparse
-    unittest2
     pycodestyle>=2.0
     pydiff>=0.1.2


### PR DESCRIPTION
EOL Python 2.6 was dropped in https://github.com/hugovk/autopep8/commit/8e5a698.

This updates the PyPI classifiers, removes some now-redundant code, and updates some other code to use things now available in 2.7+.

It also drops support for Python 3.3, which is also EOL and less used than 2.6.

Here's the pip installs for autopep8 from PyPI for last month:

| python_version | percent | download_count |
| -------------- | ------: | -------------: |
| 2.7            |  44.98% |         48,410 |
| 3.6            |  38.80% |         41,760 |
| 3.5            |  11.45% |         12,323 |
| 3.4            |   3.80% |          4,086 |
| 2.6            |   0.40% |            435 |
| 3.3            |   0.38% |            409 |
| 3.7            |   0.20% |            213 |
| 3.8            |   0.00% |              1 |

Source: `pypinfo --start-date -38 --end-date -11 --percent --pip --markdown autopep8 pyversion`