### PR TITLE
Handle ValueError from check_syntax

### DIFF
--- a/autopep8.py
+++ b/autopep8.py
@@ -2889,7 +2889,7 @@ def check_syntax(code):
     """Return True if syntax is okay."""
     try:
         return compile(code, '<string>', 'exec', dont_inherit=True)
-    except (SyntaxError, TypeError, UnicodeDecodeError):
+    except (SyntaxError, TypeError, ValueError):
         return False
 
 

--- a/test/test_autopep8.py
+++ b/test/test_autopep8.py
@@ -58,6 +58,10 @@ class UnitTests(unittest.TestCase):
 
     maxDiff = None
 
+    def test_compile_value_error(self):
+        source = '"\\xhh" \\'
+        self.assertFalse(autopep8.check_syntax(source))
+
     def test_find_newline_only_cr(self):
         source = ['print 1\r', 'print 2\r', 'print3\r']
         self.assertEqual(autopep8.CR, autopep8.find_newline(source))


### PR DESCRIPTION
UnicodeDecodeError is a subclass of ValueError

Fixes:
  ...
  File "/home/hashem/pyve2/local/lib/python2.7/site-packages/autopep8.py", line 1390, in fix_e265
    include_docstrings=True) | set(commented_out_code_lines(source))
  File "/home/hashem/pyve2/local/lib/python2.7/site-packages/autopep8.py", line 3010, in commented_out_code_lines
    check_syntax(stripped_line)
  File "/home/hashem/pyve2/local/lib/python2.7/site-packages/autopep8.py", line 2889, in check_syntax
    return compile(code, '<string>', 'exec', dont_inherit=True)
ValueError: invalid \x escape

When run on a file with:

 # "\xhh" \