### PR TITLE
Add fixer for E252 "Missing whitespace around parameter equals"

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -202,6 +202,7 @@ autopep8 fixes the following issues_ reported by pycodestyle_::
     E241 - Fix extraneous whitespace around keywords.
     E242 - Remove extraneous whitespace around operator.
     E251 - Remove whitespace around parameter '=' sign.
+    E252 - Missing whitespace around parameter equals.
     E26  - Fix spacing after comment hash for inline comments.
     E265 - Fix spacing after comment hash for block comments.
     E27  - Fix extraneous whitespace around keywords.

--- a/autopep8.py
+++ b/autopep8.py
@@ -407,7 +407,7 @@ class FixPEP8(object):
         - e211
         - e221,e222,e223,e224,e225
         - e231
-        - e251
+        - e251,e252
         - e261,e262
         - e271,e272,e273,e274
         - e301,e302,e303,e304,e306
@@ -463,6 +463,7 @@ class FixPEP8(object):
         self.fix_e228 = self.fix_e225
         self.fix_e241 = self.fix_e271
         self.fix_e242 = self.fix_e224
+        self.fix_e252 = self.fix_e225
         self.fix_e261 = self.fix_e262
         self.fix_e272 = self.fix_e271
         self.fix_e273 = self.fix_e271

--- a/test/test_autopep8.py
+++ b/test/test_autopep8.py
@@ -2084,6 +2084,24 @@ bar[zap[0][0]:zig[0][0], :]
         with autopep8_context(line) as result:
             self.assertEqual(fixed, result)
 
+    def test_e252(self):
+        line = 'def a(arg1: int=1, arg2: int =1, arg3: int= 1):\n    print arg\n'
+        fixed = 'def a(arg1: int = 1, arg2: int = 1, arg3: int = 1):\n    print arg\n'
+        with autopep8_context(line) as result:
+            self.assertEqual(fixed, result)
+
+    def test_e252_with_argument_on_next_line(self):
+        line = 'def a(arg: int\n=1):\n    print arg\n'
+        fixed = 'def a(arg: int\n= 1):\n    print arg\n'
+        with autopep8_context(line, options=['--select=E252']) as result:
+            self.assertEqual(fixed, result)
+
+    def test_e252_with_escaped_newline(self):
+        line = 'def a(arg: int\\\n=1):\n    print arg\n'
+        fixed = 'def a(arg: int\\\n= 1):\n    print arg\n'
+        with autopep8_context(line, options=['--select=E252']) as result:
+            self.assertEqual(fixed, result)
+
     def test_e261(self):
         line = "print 'a b '# comment\n"
         fixed = "print 'a b '  # comment\n"


### PR DESCRIPTION
This is a fixer for the new E252 which appeared in pycodestyle 2.4.0.

I reused the fixer for E225 which seems to work. However, I am not sure whether this is the right thing to do since it seems to be able to do more than strictly needed here.