### PR TITLE
Make test_e225_with_indentation_fix() actually use the fixer for E225

### DIFF
--- a/test/test_autopep8.py
+++ b/test/test_autopep8.py
@@ -1966,13 +1966,13 @@ class Foo():
 class Foo(object):
 
   def bar(self):
-    return self.elephant is not None
+    return self.elephant!='test'
 """
         fixed = """\
 class Foo(object):
 
     def bar(self):
-        return self.elephant is not None
+        return self.elephant != 'test'
 """
         with autopep8_context(line) as result:
             self.assertEqual(fixed, result)


### PR DESCRIPTION
Due to a change in commit f36c732ada5 ('Add fixer for E711 with "!=
None"') the test for E225 actually did not use the fixer for E225
anymore.

Fix this by returning to the original example but use a comparison that
does not trigger E711.