### PR TITLE
Implement w605 fixed method

### DIFF
--- a/autopep8.py
+++ b/autopep8.py
@@ -1208,6 +1208,48 @@ class FixPEP8(object):
             self.source[line_index - 1] = '{} {}{}'.format(
                 before_line[:bl], one_string_token, before_line[bl:])
 
+    def fix_w605(self, result):
+        (line_index, _, target) = get_index_offset_contents(result,
+                                                            self.source)
+        tokens = list(generate_tokens(target))
+        for (pos, _msg) in get_w605_position(tokens):
+            self.source[line_index] = '{}r{}'.format(
+                    target[:pos], target[pos:])
+
+
+def get_w605_position(tokens):
+    """workaround get pointing out position by W605."""
+    # TODO: When this PR(*) change is released, use pos of pycodestyle
+    # *: https://github.com/PyCQA/pycodestyle/pull/747
+    valid = [
+        '\n', '\\', '\'', '"', 'a', 'b', 'f', 'n', 'r', 't', 'v',
+        '0', '1', '2', '3', '4', '5', '6', '7', 'x',
+
+        # Escape sequences only recognized in string literals
+        'N', 'u', 'U',
+    ]
+
+    for token_type, text, start, end, line in tokens:
+        if token_type == tokenize.STRING:
+            quote = text[-3:] if text[-3:] in ('"""', "'''") else text[-1]
+            # Extract string modifiers (e.g. u or r)
+            quote_pos = text.index(quote)
+            prefix = text[:quote_pos].lower()
+            start = quote_pos + len(quote)
+            string = text[start:-len(quote)]
+
+            if 'r' not in prefix:
+                pos = string.find('\\')
+                while pos >= 0:
+                    pos += 1
+                    if string[pos] not in valid:
+                        yield (
+                            line.find(text),
+                            "W605 invalid escape sequence '\\%s'" %
+                            string[pos],
+                        )
+                    pos = string.find('\\', pos + 1)
+
 
 def get_index_offset_contents(result, source):
     """Return (line_index, column_offset, line_contents)."""

--- a/test/test_autopep8.py
+++ b/test/test_autopep8.py
@@ -4555,6 +4555,12 @@ raise ValueError("error")
         with autopep8_context(line, options=['--aggressive']) as result:
             self.assertEqual(fixed, result)
 
+    def test_w605_simple(self):
+        line = "escape = '\.jpg'\n"
+        fixed = "escape = r'\.jpg'\n"
+        with autopep8_context(line, options=['--aggressive']) as result:
+            self.assertEqual(fixed, result)
+
     def test_trailing_whitespace_in_multiline_string(self):
         line = 'x = """ \nhello"""    \n'
         fixed = 'x = """ \nhello"""\n'


### PR DESCRIPTION
* with `--aggressive` option.
* requirement `pycodestyle` version 2.4.0+
* remove `get_w605_position` function, when released [this PR](https://github.com/PyCQA/pycodestyle/pull/747). instead of `pycodestyle` of position value.