### PR TITLE
Fix invalid escape sequences in tests

### DIFF
--- a/test/test_autopep8.py
+++ b/test/test_autopep8.py
@@ -124,7 +124,7 @@ class UnitTests(unittest.TestCase):
 
     def test_multiline_string_lines(self):
         self.assertEqual(
-            set([2]),
+            {2},
             autopep8.multiline_string_lines(
                 """\
 '''
@@ -133,7 +133,7 @@ class UnitTests(unittest.TestCase):
 
     def test_multiline_string_lines_with_many(self):
         self.assertEqual(
-            set([2, 7, 10, 11, 12]),
+            {2, 7, 10, 11, 12},
             autopep8.multiline_string_lines(
                 """\
 '''
@@ -160,7 +160,7 @@ class UnitTests(unittest.TestCase):
 
     def test_multiline_string_should_not_report_docstrings(self):
         self.assertEqual(
-            set([5]),
+            {5},
             autopep8.multiline_string_lines(
                 """\
 def foo():
@@ -4729,27 +4729,27 @@ raise ValueError("error")
             self.assertEqual(fixed, result)
 
     def test_w605_simple(self):
-        line = "escape = '\.jpg'\n"
-        fixed = "escape = r'\.jpg'\n"
+        line = "escape = '\\.jpg'\n"
+        fixed = "escape = r'\\.jpg'\n"
         with autopep8_context(line, options=['--aggressive']) as result:
             self.assertEqual(fixed, result)
 
     def test_w605_identical_token(self):
         # ***NOTE***: The --pep8-passes option is requred to prevent an infinite loop in
         # the old, failing code. DO NOT REMOVE.
-        line = "escape = foo('\.bar', '\.kilroy')\n"
-        fixed = "escape = foo(r'\.bar', r'\.kilroy')\n"
+        line = "escape = foo('\\.bar', '\\.kilroy')\n"
+        fixed = "escape = foo(r'\\.bar', r'\\.kilroy')\n"
         with autopep8_context(line, options=['--aggressive', '--pep8-passes', '5']) as result:
             self.assertEqual(fixed, result, "Two tokens get r added")
 
-        line = "escape = foo('\.bar', r'\.kilroy')\n"
-        fixed = "escape = foo(r'\.bar', r'\.kilroy')\n"
+        line = "escape = foo('\\.bar', r'\\.kilroy')\n"
+        fixed = "escape = foo(r'\\.bar', r'\\.kilroy')\n"
         with autopep8_context(line, options=['--aggressive', '--pep8-passes', '5']) as result:
             self.assertEqual(fixed, result, "r not added if already there")
 
         # Test Case to catch bad behavior reported in Issue #449
-        line = "escape = foo('\.bar', '\.bar')\n"
-        fixed = "escape = foo(r'\.bar', r'\.bar')\n"
+        line = "escape = foo('\\.bar', '\\.bar')\n"
+        fixed = "escape = foo(r'\\.bar', r'\\.bar')\n"
         with autopep8_context(line, options=['--aggressive', '--pep8-passes', '5']) as result:
             self.assertEqual(fixed, result)
 


### PR DESCRIPTION
This was noticed while running `pytest test --collect-only`.  I fixed this
automatically by using [pyupgrade](https://github.com/asottile/pyupgrade).