### PR TITLE
fix import moved above a future import

### DIFF
--- a/autopep8.py
+++ b/autopep8.py
@@ -57,6 +57,7 @@ import sys
 import textwrap
 import token
 import tokenize
+import ast
 
 import pycodestyle
 
@@ -1400,6 +1401,14 @@ def get_module_imports_on_top_of_file(source, import_line_index):
         if line and line[0] in 'rR':
             line = line[1:]
         return line and (line[0] == '"' or line[0] == "'")
+
+    def is_future_import(line):
+        nodes = ast.parse(line)
+        for n in nodes.body:
+            if isinstance(n, ast.ImportFrom) and n.module == '__future__':
+                return True
+        return False
+
     allowed_try_keywords = ('try', 'except', 'else', 'finally')
     for cnt, line in enumerate(source):
         if not line.rstrip():
@@ -1407,7 +1416,7 @@ def get_module_imports_on_top_of_file(source, import_line_index):
         elif line.startswith('#'):
             continue
         if line.startswith('import ') or line.startswith('from '):
-            if cnt == import_line_index:
+            if cnt == import_line_index or is_future_import(line):
                 continue
             return cnt
         elif pycodestyle.DUNDER_REGEX.match(line):

--- a/test/test_autopep8.py
+++ b/test/test_autopep8.py
@@ -2416,6 +2416,12 @@ a = 1     # (E305)
         with autopep8_context(line) as result:
             self.assertEqual(fixed, result)
 
+    def test_e402_with_future_import(self):
+        line = 'from __future__ import print_function\na = 1\nimport os\n'
+        fixed = 'from __future__ import print_function\nimport os\na = 1\n'
+        with autopep8_context(line) as result:
+            self.assertEqual(fixed, result)
+
     def test_e402_import_some_modules(self):
         line = """\
 a = 1


### PR DESCRIPTION
As you can see in issue #459, `autopep8` will move import aboved a `from __future__ import xxx`, leading a syntax error.

Following code

```Python
from __future__ import print_function
a = 1
import os
```

will be converted to

```Python
import os
from __future__ import print_function
a = 1
```

So, I wanna to pull request to solve it : )