### PR TITLE
fix import statement moved above the module doc by E402

### DIFF
--- a/test/test_autopep8.py
+++ b/test/test_autopep8.py
@@ -2422,6 +2422,20 @@ a = 1     # (E305)
         with autopep8_context(line) as result:
             self.assertEqual(fixed, result)
 
+    def test_e402_with_module_doc(self):
+        line1 = '"""\nmodule doc\n"""\na = 1\nimport os\n'
+        fixed1 = '"""\nmodule doc\n"""\nimport os\na = 1\n'
+        line2 = '# comment\nr"""\nmodule doc\n"""\na = 1\nimport os\n'
+        fixed2 = '# comment\nr"""\nmodule doc\n"""\nimport os\na = 1\n'
+        line3 = "u'''one line module doc'''\na = 1\nimport os\n"
+        fixed3 = "u'''one line module doc'''\nimport os\na = 1\n"
+        line4 = "'''\n\"\"\"\ndoc'''\na = 1\nimport os\n"
+        fixed4 = "'''\n\"\"\"\ndoc'''\nimport os\na = 1\n"
+        for line, fixed in [(line1, fixed1), (line2, fixed2),
+                            (line3, fixed3), (line4, fixed4)]:
+            with autopep8_context(line) as result:
+                self.assertEqual(fixed, result)
+
     def test_e402_import_some_modules(self):
         line = """\
 a = 1
@@ -4882,7 +4896,7 @@ if True:
         target_line_index = 11
         result = get_module_imports_on_top_of_file(line.splitlines(),
                                                    target_line_index)
-        self.assertEqual(result, 5)
+        self.assertEqual(result, 10)
 
 
 class CommandLineTests(unittest.TestCase):


### PR DESCRIPTION
This pull request resolves that `import` statement moved above the module document when fixing E402. I don't want to use the `pycodestyle.DOCSTRING_REGEX` to check whether this line is a docstring. Because `pycodestyle` implement it as:

```Python
DOCSTRING_REGEX = re.compile(r'u?r?["\']')
```

In [PEP 257 -- Docstring Conventions](https://www.python.org/dev/peps/pep-0257/#what-is-a-docstring)

> For consistency, always use """triple double quotes""" around docstrings. Use r"""raw triple double quotes""" if you use any backslashes in your docstrings. For Unicode docstrings, use u"""Unicode triple-quoted strings""".

So, I add a regex `DOCSTRING_START_REGEX` to match the module doc prefix.

resolves #459 