### PR TITLE
E704 indent

### DIFF
--- a/autopep8.py
+++ b/autopep8.py
@@ -81,7 +81,7 @@ LAMBDA_REGEX = re.compile(r'([\w.]+)\s=\slambda\s*([\(\)=\w,\s.]*):')
 COMPARE_NEGATIVE_REGEX = re.compile(r'\b(not)\s+([^][)(}{]+?)\s+(in|is)\s')
 COMPARE_NEGATIVE_REGEX_THROUGH = re.compile(r'\b(not\s+in|is\s+not)\s')
 BARE_EXCEPT_REGEX = re.compile(r'except\s*:')
-STARTSWITH_DEF_REGEX = re.compile(r'^(async\s+def|def)\s.*\):')
+STARTSWITH_DEF_REGEX = re.compile(r'^\s*(async\s+def|def)\s.*\):')
 DOCSTRING_START_REGEX = re.compile(r'^u?r?(?P<kind>["\']{3})')
 
 EXIT_CODE_OK = 0

--- a/test/test_autopep8.py
+++ b/test/test_autopep8.py
@@ -3933,6 +3933,12 @@ def example2(): return ('' in {'f': 2}) in {'has_key() is deprecated': True}
         with autopep8_context(line, options=['-aa', '--select=E704']) as result:
             self.assertEqual(line, result)
 
+    def test_e704_indented(self):
+        line = 'class C:\n    def f(x): return 2*x\n'
+        fixed = 'class C:\n    def f(x):\n        return 2 * x\n'
+        with autopep8_context(line, options=['-aaa']) as result:
+            self.assertEqual(fixed, result)
+
     def test_e711(self):
         line = 'foo == None\n'
         fixed = 'foo is None\n'


### PR DESCRIPTION
If E704 is indented, this regexp doesn't match, so it will not fix the error. I only added possible whitespace indent, to be able to fix indented definition.