### PR TITLE
Remove duplicated aggresive option in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -46,7 +46,7 @@ Usage
 
 To modify a file in place (with aggressive level 2)::
 
-    $ autopep8 --in-place --aggressive --aggressive <filename>
+    $ autopep8 --in-place --aggressive <filename>
 
 Before running autopep8.
 


### PR DESCRIPTION
The `--aggresive` option was duplicated in one of the examples in the README. The command works the same, but there is no reason to be that aggressive! :rofl: 