### PR TITLE
Fix for Python 3.10: don't assume major.minor is 3 chars

### DIFF
--- a/test/example_with_reduce.py
+++ b/test/example_with_reduce.py
@@ -202,7 +202,7 @@ class UnknownExtra(ResolutionError):
     """Distribution doesn't have an "extra feature" of the given name"""
 _provider_factories = {}
 
-PY_MAJOR = sys.version[:3]
+PY_MAJOR = "{}.{}".format(*sys.version_info)
 EGG_DIST = 3
 BINARY_DIST = 2
 SOURCE_DIST = 1


### PR DESCRIPTION
It's safer to use the `sys.version_info` tuple for version operations, than using the `sys.version` string.

Using the `sys.version` string can lead to problems when assuming the length of each version component is only one character, which will not be the case for Python 3.10.

```pycon
>>> sys.version
'3.8.1 (v3.8.1:1b293b6006, Dec 18 2019, 14:08:53) \n[Clang 6.0 (clang-600.0.57)]'
>>> sys.version[:3]
'3.8'
>>> fake_3_10 = '3.10.1 (v3.8.1:1b293b6006, Dec 18 2019, 14:08:53) \n[Clang 6.0 (clang-600.0.57)]'
>>> fake_3_10[:3]
'3.1'
>>> sys.version_info
sys.version_info(major=3, minor=8, micro=1, releaselevel='final', serial=0)
>>> "{}.{}".format(*sys.version_info)
'3.8'
>>>
```