### PR TITLE
Fix a bug causing both W503 and W504 to be ignored

### DIFF
--- a/autopep8.py
+++ b/autopep8.py
@@ -3742,8 +3742,8 @@ def parse_args(arguments, apply_config=False):
 
     if args.ignore:
         args.ignore = _split_comma_separated(args.ignore)
-        if not all(
-                any(
+        if all(
+                not any(
                     conflicting_code.startswith(ignore_code)
                     for ignore_code in args.ignore
                 )

--- a/test/test_autopep8.py
+++ b/test/test_autopep8.py
@@ -4402,6 +4402,32 @@ else:
         with autopep8_context(line, options=['--select=W503']) as result:
             self.assertEqual(fixed, result)
 
+    def test_w503_with_ignore_w504(self):
+        line = '(width == 0\n + height == 0)\n'
+        fixed = '(width == 0 +\n height == 0)\n'
+        with autopep8_context(line, options=['--ignore=E,W504']) as result:
+            self.assertEqual(fixed, result)
+
+    def test_w504_with_ignore_w503(self):
+        line = '(width == 0 +\n height == 0)\n'
+        fixed = '(width == 0\n + height == 0)\n'
+        with autopep8_context(line, options=['--ignore=E,W503']) as result:
+            self.assertEqual(fixed, result)
+
+    def test_w503_w504_none_ignored(self):
+        line = '(width == 0 +\n height == 0\n+ depth == 0)\n'
+        fixed = '(width == 0 +\n height == 0\n+ depth == 0)\n'
+        with autopep8_context(line, options=['--ignore=E']) as result:
+            self.assertEqual(fixed, result)
+
+    def test_w503_w504_both_ignored(self):
+        line = '(width == 0 +\n height == 0\n+ depth == 0)\n'
+        fixed = '(width == 0 +\n height == 0\n+ depth == 0)\n'
+        with autopep8_context(
+            line, options=['--ignore=E,W503, W504'],
+        ) as result:
+            self.assertEqual(fixed, result)
+
     def test_w503_skip_default(self):
         line = '(width == 0\n + height == 0)\n'
         with autopep8_context(line) as result:


### PR DESCRIPTION
This happens when either `W503` or `W504` is in the `ignore` list, `autopep8` decided to ignore both of them - which it shouldn't.