### PR TITLE
return diff exit code when reading from stdin too

### DIFF
--- a/autopep8.py
+++ b/autopep8.py
@@ -4281,11 +4281,16 @@ def main(argv=None, apply_config=True):
             assert not args.in_place
 
             encoding = sys.stdin.encoding or get_encoding()
+            read_stdin = sys.stdin.read()
+            fixed_stdin = fix_code(read_stdin, args, encoding=encoding)
 
             # LineEndingWrapper is unnecessary here due to the symmetry between
             # standard in and standard out.
-            wrap_output(sys.stdout, encoding=encoding).write(
-                fix_code(sys.stdin.read(), args, encoding=encoding))
+            wrap_output(sys.stdout, encoding=encoding).write(fixed_stdin)
+
+            if hash(read_stdin) != hash(fixed_stdin):
+                if args.exit_code:
+                    return EXIT_CODE_EXISTS_DIFF
         else:
             if args.in_place or args.diff:
                 args.files = list(set(args.files))

--- a/test/test_autopep8.py
+++ b/test/test_autopep8.py
@@ -5378,6 +5378,17 @@ class CommandLineTests(unittest.TestCase):
             fixed,
             process.communicate(line.encode('utf-8'))[0].decode('utf-8'))
 
+    def test_exit_code_should_be_set_when_standard_in(self):
+        line = 'print( 1 )\n'
+        process = Popen(list(AUTOPEP8_CMD_TUPLE) +
+                        ['--exit-code', '-'],
+                        stdout=PIPE,
+                        stdin=PIPE)
+        process.communicate(line.encode('utf-8'))[0].decode('utf-8')
+        self.assertEqual(
+            process.returncode,
+            autopep8.EXIT_CODE_EXISTS_DIFF)
+
 
 class ConfigurationTests(unittest.TestCase):
 


### PR DESCRIPTION
Hi! When reading from stdin `autopep8` is not setting exit code when the code could be fixed.

For example purposes, when passing a file using `<`
```
autopep8 --exit-code - < /path/to/fixable/code
```
It was expected to return with some status code regarding that the code could be fixed, but it did not.

In case of `pycodestyle`, it does set exit code when also read from stdin and detecting errors.

This is a simple patch fixing this behavior, I'd welcome any feedback. I've also added a test for this case.

---

* pycodestyle behaves correctly (or, at least, differently)
* `autopep8 1.5 (pycodestyle: 2.5.0)`
* Python 3.8.1
* Linux archpux 5.5.4-arch1-1 #1 SMP PREEMPT Sat, 15 Feb 2020 00:36:29 +0000 x86_64 GNU/Linux
* Example input: any fixable piece of code read from standard input
* Command: `autopep8 --exit-code - < /path/to/fixable/code`
* Expected output: exit code set to EXIT_CODE_DIFF_EXISTS
* Occurs on latest autopep8
