### PR TITLE
incorrect E702 fixes with --select=E702 option

### DIFF
--- a/autopep8.py
+++ b/autopep8.py
@@ -1033,8 +1033,7 @@ class FixPEP8(object):
                 if self.options.verbose:
                     print(
                         '---> avoid fixing {error} with '
-                        'other compound statements'.format(error=result['id'],
-                                                           ine=result['line']),
+                        'other compound statements'.format(error=result['id']),
                         file=sys.stderr
                     )
                 return []

--- a/autopep8.py
+++ b/autopep8.py
@@ -67,6 +67,7 @@ except ImportError:
     from ConfigParser import Error
 
 import pycodestyle
+from pycodestyle import STARTSWITH_INDENT_STATEMENT_REGEX
 
 
 try:
@@ -1028,7 +1029,14 @@ class FixPEP8(object):
         # https://docs.python.org/reference/compound_stmts.html
         for line in logical_lines:
             if (result['id'] == 'E702' and ':' in line
-                    and STARTSWITH_DEF_REGEX.match(line)):
+                    and STARTSWITH_INDENT_STATEMENT_REGEX.match(line)):
+                if self.options.verbose:
+                    print(
+                        '---> avoid fixing {error} with '
+                        'other compound statements'.format(error=result['id'],
+                                                           ine=result['line']),
+                        file=sys.stderr
+                    )
                 return []
 
         line_index = result['line'] - 1

--- a/test/test_autopep8.py
+++ b/test/test_autopep8.py
@@ -4017,6 +4017,15 @@ MY_CONST = [
         with autopep8_context(line) as result:
             self.assertEqual(fixed, result)
 
+    def test_e702_with_e701_and_only_select_e702_option(self):
+        line = """\
+for i in range(3):
+    if i == 1: print i; continue
+    print i
+"""
+        with autopep8_context(line, options=["--select=E702"]) as result:
+            self.assertEqual(line, result)
+
     def test_e703_with_inline_comment(self):
         line = 'a = 5;    # inline comment\n'
         fixed = 'a = 5    # inline comment\n'

--- a/test/test_autopep8.py
+++ b/test/test_autopep8.py
@@ -5284,6 +5284,19 @@ class CommandLineTests(unittest.TestCase):
             verbose_error = p.communicate()[1].decode('utf-8')
         self.assertIn('------------', verbose_error)
 
+    def test_verbose_with_select_e702(self):
+        line = """\
+for i in range(3):
+    if i == 1: print i; continue
+    print i
+"""
+        with temporary_file_context(line) as filename:
+            p = Popen(list(AUTOPEP8_CMD_TUPLE) +
+                      [filename, '-vvv', '--select=E702'],
+                      stdout=PIPE, stderr=PIPE)
+            verbose_error = p.communicate()[1].decode('utf-8')
+        self.assertIn(" with other compound statements", verbose_error)
+
     def test_in_place(self):
         line = "'abc'  \n"
         fixed = "'abc'\n"


### PR DESCRIPTION
for #364 

If E701 and E702 exist in the same line, do not correct them.