### PR TITLE
Add support for skipping formatting of a block in a file

### DIFF
--- a/autopep8.py
+++ b/autopep8.py
@@ -3303,7 +3303,6 @@ def filter_results(source, results, aggressive):
 
     # Filter out the disabled ranges
     disabled_ranges = get_disabled_ranges(source)
-    print("disabled_ranges: {}".format(disabled_ranges))
     if len(disabled_ranges) > 0:
         results = [result for result in results
                    if any(result['line'] not in range(*disabled_range)

--- a/autopep8.py
+++ b/autopep8.py
@@ -3303,10 +3303,12 @@ def filter_results(source, results, aggressive):
 
     # Filter out the disabled ranges
     disabled_ranges = get_disabled_ranges(source)
-    results = [result for result in results
-               if any(result['line'] not in range(*disabled_range)
-                      for disabled_range in disabled_ranges)
-              ]
+    print("disabled_ranges: {}".format(disabled_ranges))
+    if len(disabled_ranges) > 0:
+        results = [result for result in results
+                   if any(result['line'] not in range(*disabled_range)
+                          for disabled_range in disabled_ranges)
+                  ]
 
     has_e901 = any(result['id'].lower() == 'e901' for result in results)
 

--- a/autopep8.py
+++ b/autopep8.py
@@ -3224,9 +3224,12 @@ def check_syntax(code):
         return False
 
 
-def find_with_line_numbers(pattern, contents, flags=0):
-    """A version of 're.finditer' that returns '(match, line_number)' pairs."""
-    matches = list(re.finditer(pattern, contents, flags))
+def find_with_line_numbers(pattern, contents):
+    """A wrapper around 're.finditer' to find line numbers.
+
+    Returns a list of line numbers where pattern was found in contents.
+    """
+    matches = list(re.finditer(pattern, contents))
     if not matches:
         return []
 
@@ -3252,9 +3255,8 @@ def find_with_line_numbers(pattern, contents, flags=0):
 
 
 def get_disabled_ranges(source):
-    """Returns tuples representing the ranges where autopep8 is disabled
+    """Returns a list of tuples representing the disabled ranges.
 
-    Deals with disabling twice before enabling and enabling when not disabled.
     If disabled and no re-enable will disable for rest of file.
 
     """

--- a/autopep8.py
+++ b/autopep8.py
@@ -3248,7 +3248,7 @@ def find_with_line_numbers(pattern, contents, flags=0):
         newline_offset = contents.rfind('\n', 0, match.start())
         return newline_offsets[newline_offset]
 
-    return [get_line_num(match, contents) for match in matches]
+    return [get_line_num(match, contents) + 1 for match in matches]
 
 
 def get_disabled_ranges(source):
@@ -3256,6 +3256,7 @@ def get_disabled_ranges(source):
 
     Deals with disabling twice before enabling and enabling when not disabled.
     If disabled and no re-enable will disable for rest of file.
+
     """
     enable_line_nums = find_with_line_numbers(ENABLE_REGEX, source)
     disable_line_nums = find_with_line_numbers(DISABLE_REGEX, source)

--- a/autopep8.py
+++ b/autopep8.py
@@ -3235,7 +3235,10 @@ def find_with_line_numbers(pattern, contents):
 
     end = matches[-1].start()
 
-    newline_offsets = {-1: 0} # -1 so a failed `rfind` maps to the first line.
+    # -1 so a failed `rfind` maps to the first line.
+    newline_offsets = {
+        -1: 0
+    }
     for line_num, m in enumerate(re.finditer(r'\n', contents), 1):
         offset = m.start()
         if offset > end:
@@ -3307,7 +3310,7 @@ def filter_results(source, results, aggressive):
         results = [result for result in results
                    if any(result['line'] not in range(*disabled_range)
                           for disabled_range in disabled_ranges)
-                  ]
+                   ]
 
     has_e901 = any(result['id'].lower() == 'e901' for result in results)
 

--- a/test/test_autopep8.py
+++ b/test/test_autopep8.py
@@ -5175,8 +5175,6 @@ with open(filename) as f:
         with autopep8_context(line) as result:
             self.assertEqual(line, result)
 
-class AutoFormatDisableTests(unittest.TestCase):
-
     def test_autopep8_disable(self):
         test_code = """\
 # autopep8: off
@@ -5217,6 +5215,58 @@ def f():
          'Heaven hath no wrath like love to hatred turned. Nor hell a fury like a woman scorned.'),
         ('xxxxxxx', 'yyyyyyyyyyy', "To the last I grapple with thee. From hell's heart I stab at thee. For hate's sake I spit my last breath at thee!")])
 # fmt: on
+"""
+        with autopep8_context(test_code) as result:
+            self.assertEqual(expected_output, result)
+
+    def test_fmt_disable_without_reenable(self):
+        test_code = """\
+# fmt: off
+print(123)
+"""
+        expected_output = """\
+# fmt: off
+print(123)
+"""
+        with autopep8_context(test_code) as result:
+            self.assertEqual(expected_output, result)
+
+    def test_fmt_disable_with_double_reenable(self):
+        test_code = """\
+# fmt: off
+print( 123 )
+# fmt: on
+print( 123 )
+# fmt: on
+print( 123 )
+"""
+        expected_output = """\
+# fmt: off
+print( 123 )
+# fmt: on
+print(123)
+# fmt: on
+print(123)
+"""
+        with autopep8_context(test_code) as result:
+            self.assertEqual(expected_output, result)
+
+    def test_fmt_double_disable_and_reenable(self):
+        test_code = """\
+# fmt: off
+print( 123 )
+# fmt: off
+print( 123 )
+# fmt: on
+print( 123 )
+"""
+        expected_output = """\
+# fmt: off
+print( 123 )
+# fmt: off
+print( 123 )
+# fmt: on
+print(123)
 """
         with autopep8_context(test_code) as result:
             self.assertEqual(expected_output, result)
@@ -5334,59 +5384,6 @@ Only actual code should be reindented.
 """
         with autopep8_context(test_code) as result:
             self.assertEqual(expected_output, result)
-
-    def test_fmt_disable_without_reenable(self):
-        test_code = """\
-# fmt: off
-print(123)
-"""
-        expected_output = """\
-# fmt: off
-print(123)
-"""
-        with autopep8_context(test_code) as result:
-            self.assertEqual(expected_output, result)
-
-    def test_fmt_disable_with_double_reenable(self):
-        test_code = """\
-# fmt: off
-print( 123 )
-# fmt: on
-print( 123 )
-# fmt: on
-print( 123 )
-"""
-        expected_output = """\
-# fmt: off
-print( 123 )
-# fmt: on
-print(123)
-# fmt: on
-print(123)
-"""
-        with autopep8_context(test_code) as result:
-            self.assertEqual(expected_output, result)
-
-    def test_fmt_double_disable_and_reenable(self):
-        test_code = """\
-# fmt: off
-print( 123 )
-# fmt: off
-print( 123 )
-# fmt: on
-print( 123 )
-"""
-        expected_output = """\
-# fmt: off
-print( 123 )
-# fmt: off
-print( 123 )
-# fmt: on
-print(123)
-"""
-        with autopep8_context(test_code) as result:
-            self.assertEqual(expected_output, result)
-
 
 class UtilityFunctionTests(unittest.TestCase):
 

--- a/test/test_autopep8.py
+++ b/test/test_autopep8.py
@@ -6006,8 +6006,7 @@ class ConfigurationFileTests(unittest.TestCase):
             target_filename = os.path.join(dirname, "foo.py")
             with open(target_filename, "w") as fp:
                 fp.write(line)
-            p = Popen(list(AUTOPEP8_CMD_TUPLE) +
-                      [target_filename], stdout=PIPE)
+            p = Popen(list(AUTOPEP8_CMD_TUPLE) + [target_filename], stdout=PIPE)
             self.assertEqual(p.communicate()[0].decode("utf-8"), line)
             self.assertEqual(p.returncode, 0)
 
@@ -6022,8 +6021,7 @@ class ConfigurationFileTests(unittest.TestCase):
             target_filename = os.path.join(dirname, "foo.py")
             with open(target_filename, "w") as fp:
                 fp.write(line)
-            p = Popen(list(AUTOPEP8_CMD_TUPLE) +
-                      [target_filename, "-vvv"], stdout=PIPE)
+            p = Popen(list(AUTOPEP8_CMD_TUPLE) + [target_filename, "-vvv"], stdout=PIPE)
             output = p.communicate()[0].decode("utf-8")
             self.assertTrue(line in output)
             self.assertTrue(verbose_line in output)
@@ -6038,8 +6036,7 @@ class ConfigurationFileTests(unittest.TestCase):
             target_filename = os.path.join(dirname, "foo.py")
             with open(target_filename, "w") as fp:
                 fp.write(line)
-            p = Popen(list(AUTOPEP8_CMD_TUPLE) +
-                      [target_filename, ], stdout=PIPE)
+            p = Popen(list(AUTOPEP8_CMD_TUPLE) + [target_filename, ], stdout=PIPE)
             output = p.communicate()[0].decode("utf-8")
             self.assertTrue(line in output)
             self.assertEqual(p.returncode, 0)

--- a/test/test_autopep8.py
+++ b/test/test_autopep8.py
@@ -5175,6 +5175,218 @@ with open(filename) as f:
         with autopep8_context(line) as result:
             self.assertEqual(line, result)
 
+class AutoFormatDisableTests(unittest.TestCase):
+
+    def test_autopep8_disable(self):
+        test_code = """\
+# autopep8: off
+def f():
+    aaaaaaaaaaa.bbbbbbb([
+        ('xxxxxxxxxx', 'yyyyyy',
+         'Heaven hath no wrath like love to hatred turned. Nor hell a fury like a woman scorned.'),
+        ('xxxxxxx', 'yyyyyyyyyyy', "To the last I grapple with thee. From hell's heart I stab at thee. For hate's sake I spit my last breath at thee!")])
+# autopep8: on
+"""
+        expected_output = """\
+# autopep8: off
+def f():
+    aaaaaaaaaaa.bbbbbbb([
+        ('xxxxxxxxxx', 'yyyyyy',
+         'Heaven hath no wrath like love to hatred turned. Nor hell a fury like a woman scorned.'),
+        ('xxxxxxx', 'yyyyyyyyyyy', "To the last I grapple with thee. From hell's heart I stab at thee. For hate's sake I spit my last breath at thee!")])
+# autopep8: on
+"""
+        with autopep8_context(test_code) as result:
+            self.assertEqual(expected_output, result)
+
+    def test_fmt_disable(self):
+        test_code = """\
+# fmt: off
+def f():
+    aaaaaaaaaaa.bbbbbbb([
+        ('xxxxxxxxxx', 'yyyyyy',
+         'Heaven hath no wrath like love to hatred turned. Nor hell a fury like a woman scorned.'),
+        ('xxxxxxx', 'yyyyyyyyyyy', "To the last I grapple with thee. From hell's heart I stab at thee. For hate's sake I spit my last breath at thee!")])
+# fmt: on
+"""
+        expected_output = """\
+# fmt: off
+def f():
+    aaaaaaaaaaa.bbbbbbb([
+        ('xxxxxxxxxx', 'yyyyyy',
+         'Heaven hath no wrath like love to hatred turned. Nor hell a fury like a woman scorned.'),
+        ('xxxxxxx', 'yyyyyyyyyyy', "To the last I grapple with thee. From hell's heart I stab at thee. For hate's sake I spit my last breath at thee!")])
+# fmt: on
+"""
+        with autopep8_context(test_code) as result:
+            self.assertEqual(expected_output, result)
+
+    def test_general_disable(self):
+        test_code = """\
+# fmt: off
+
+import math, sys;
+
+def example1():
+    # This is a long comment. This should be wrapped to fit within 72 characters.
+    some_tuple=(   1,2, 3,'a'  );
+    some_variable={'long':'Long code lines should be wrapped within 79 characters.',
+    'other':[math.pi, 100,200,300,9876543210,'This is a long string that goes on'],
+    'more':{'inner':'This whole logical line should be wrapped.',some_tuple:[1,
+    20,300,40000,500000000,60000000000000000]}}
+    return (some_tuple, some_variable)
+def example2(): return {'has_key() is deprecated':True}.has_key(
+    {'f':2}.has_key(''));
+class Example3(   object ):
+    def __init__    ( self, bar ):
+    # Comments should have a space after the hash.
+    if bar : bar+=1;  bar=bar* bar   ; return bar
+    else:
+        some_string = '''
+                    Indentation in multiline strings should not be touched.
+Only actual code should be reindented.
+'''
+        return (sys.path, some_string)
+# fmt: on
+
+import math, sys;
+
+def example1():
+    # This is a long comment. This should be wrapped to fit within 72 characters.
+    some_tuple=(   1,2, 3,'a'  );
+    some_variable={'long':'Long code lines should be wrapped within 79 characters.',
+    'other':[math.pi, 100,200,300,9876543210,'This is a long string that goes on'],
+    'more':{'inner':'This whole logical line should be wrapped.',some_tuple:[1,
+    20,300,40000,500000000,60000000000000000]}}
+    return (some_tuple, some_variable)
+def example2(): return {'has_key() is deprecated':True}.has_key(
+    {'f':2}.has_key(''));
+class Example3(   object ):
+    def __init__    ( self, bar ):
+    # Comments should have a space after the hash.
+    if bar : bar+=1;  bar=bar* bar   ; return bar
+    else:
+        some_string = '''
+                    Indentation in multiline strings should not be touched.
+Only actual code should be reindented.
+'''
+        return (sys.path, some_string)
+
+
+"""
+        expected_output = """\
+# fmt: off
+
+import sys
+import math
+import math, sys;
+
+def example1():
+    # This is a long comment. This should be wrapped to fit within 72 characters.
+    some_tuple=(   1,2, 3,'a'  );
+    some_variable={'long':'Long code lines should be wrapped within 79 characters.',
+    'other':[math.pi, 100,200,300,9876543210,'This is a long string that goes on'],
+    'more':{'inner':'This whole logical line should be wrapped.',some_tuple:[1,
+    20,300,40000,500000000,60000000000000000]}}
+    return (some_tuple, some_variable)
+def example2(): return {'has_key() is deprecated':True}.has_key(
+    {'f':2}.has_key(''));
+class Example3(   object ):
+    def __init__    ( self, bar ):
+    # Comments should have a space after the hash.
+    if bar : bar+=1;  bar=bar* bar   ; return bar
+    else:
+        some_string = '''
+                    Indentation in multiline strings should not be touched.
+Only actual code should be reindented.
+'''
+        return (sys.path, some_string)
+# fmt: on
+
+
+def example1():
+    # This is a long comment. This should be wrapped to fit within 72 characters.
+    some_tuple = (1, 2, 3, 'a')
+    some_variable = {'long': 'Long code lines should be wrapped within 79 characters.',
+                     'other': [math.pi, 100, 200, 300, 9876543210, 'This is a long string that goes on'],
+                     'more': {'inner': 'This whole logical line should be wrapped.', some_tuple: [1,
+                                                                                                  20, 300, 40000, 500000000, 60000000000000000]}}
+    return (some_tuple, some_variable)
+
+
+def example2(): return {'has_key() is deprecated': True}.has_key(
+    {'f': 2}.has_key(''))
+
+
+class Example3(object):
+    def __init__(self, bar):
+        # Comments should have a space after the hash.
+    if bar:
+        bar += 1
+        bar = bar * bar
+        return bar
+    else:
+        some_string = '''
+                    Indentation in multiline strings should not be touched.
+Only actual code should be reindented.
+'''
+        return (sys.path, some_string)
+"""
+        with autopep8_context(test_code) as result:
+            self.assertEqual(expected_output, result)
+
+    def test_fmt_disable_without_reenable(self):
+        test_code = """\
+# fmt: off
+print(123)
+"""
+        expected_output = """\
+# fmt: off
+print(123)
+"""
+        with autopep8_context(test_code) as result:
+            self.assertEqual(expected_output, result)
+
+    def test_fmt_disable_with_double_reenable(self):
+        test_code = """\
+# fmt: off
+print( 123 )
+# fmt: on
+print( 123 )
+# fmt: on
+print( 123 )
+"""
+        expected_output = """\
+# fmt: off
+print( 123 )
+# fmt: on
+print(123)
+# fmt: on
+print(123)
+"""
+        with autopep8_context(test_code) as result:
+            self.assertEqual(expected_output, result)
+
+    def test_fmt_double_disable_and_reenable(self):
+        test_code = """\
+# fmt: off
+print( 123 )
+# fmt: off
+print( 123 )
+# fmt: on
+print( 123 )
+"""
+        expected_output = """\
+# fmt: off
+print( 123 )
+# fmt: off
+print( 123 )
+# fmt: on
+print(123)
+"""
+        with autopep8_context(test_code) as result:
+            self.assertEqual(expected_output, result)
+
 
 class UtilityFunctionTests(unittest.TestCase):
 
@@ -7096,7 +7308,6 @@ def d():
 """
         with autopep8_context(line, options=['--experimental']) as result:
             self.assertEqual(fixed, result)
-
 
 @contextlib.contextmanager
 def autopep8_context(line, options=None):

--- a/test/test_autopep8.py
+++ b/test/test_autopep8.py
@@ -5385,6 +5385,7 @@ Only actual code should be reindented.
         with autopep8_context(test_code) as result:
             self.assertEqual(expected_output, result)
 
+
 class UtilityFunctionTests(unittest.TestCase):
 
     def test_get_module_imports(self):
@@ -6005,7 +6006,8 @@ class ConfigurationFileTests(unittest.TestCase):
             target_filename = os.path.join(dirname, "foo.py")
             with open(target_filename, "w") as fp:
                 fp.write(line)
-            p = Popen(list(AUTOPEP8_CMD_TUPLE) + [target_filename], stdout=PIPE)
+            p = Popen(list(AUTOPEP8_CMD_TUPLE) +
+                      [target_filename], stdout=PIPE)
             self.assertEqual(p.communicate()[0].decode("utf-8"), line)
             self.assertEqual(p.returncode, 0)
 
@@ -6020,7 +6022,8 @@ class ConfigurationFileTests(unittest.TestCase):
             target_filename = os.path.join(dirname, "foo.py")
             with open(target_filename, "w") as fp:
                 fp.write(line)
-            p = Popen(list(AUTOPEP8_CMD_TUPLE) + [target_filename, "-vvv"], stdout=PIPE)
+            p = Popen(list(AUTOPEP8_CMD_TUPLE) +
+                      [target_filename, "-vvv"], stdout=PIPE)
             output = p.communicate()[0].decode("utf-8")
             self.assertTrue(line in output)
             self.assertTrue(verbose_line in output)
@@ -6035,7 +6038,8 @@ class ConfigurationFileTests(unittest.TestCase):
             target_filename = os.path.join(dirname, "foo.py")
             with open(target_filename, "w") as fp:
                 fp.write(line)
-            p = Popen(list(AUTOPEP8_CMD_TUPLE) + [target_filename, ], stdout=PIPE)
+            p = Popen(list(AUTOPEP8_CMD_TUPLE) +
+                      [target_filename, ], stdout=PIPE)
             output = p.communicate()[0].decode("utf-8")
             self.assertTrue(line in output)
             self.assertEqual(p.returncode, 0)
@@ -7305,6 +7309,7 @@ def d():
 """
         with autopep8_context(line, options=['--experimental']) as result:
             self.assertEqual(fixed, result)
+
 
 @contextlib.contextmanager
 def autopep8_context(line, options=None):


### PR DESCRIPTION
As requested in #460 it would be nice to be able toggle support formatting on and off. It has been implemented as:
```
# autopep8: off
# autopep8: on
```
or
```
# fmt: off
# fmt: on
```

I am **not** 100% sure that I have managed to run all of the tests correctly. This needs to be checked before merging.