### PR TITLE
Restore the original pep8 copyright notice

### DIFF
--- a/autopep8.py
+++ b/autopep8.py
@@ -24,6 +24,29 @@
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+# Copyright (C) 2006-2009 Johann C. Rocholl <johann@rocholl.net>
+# Copyright (C) 2009-2013 Florent Xicluna <florent.xicluna@gmail.com>
+#
+# Permission is hereby granted, free of charge, to any person
+# obtaining a copy of this software and associated documentation files
+# (the "Software"), to deal in the Software without restriction,
+# including without limitation the rights to use, copy, modify, merge,
+# publish, distribute, sublicense, and/or sell copies of the Software,
+# and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+# BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+# ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
 """Automatically formats Python code to conform to the PEP 8 style guide.
 
 Fixes that only need be done once can be added by adding a function of the form


### PR DESCRIPTION
I guess this should have been done with the following commit:

    commit 0f06de12f6a1eaab646089f7c38f1d38a035967c
    Author: Steven Myint <git@stevenmyint.com>
    Date:   Sat Sep 7 12:52:08 2013 -0700

        Get indentation information directly from pep8

        This greatly speeds up the "E12" indentation fixes.

The copyright notice text in this commit was copied from an old version
of pycodestyle/pep8. (commit 016cbe45f64519785fed68cb4f254d8af35ce8fb)