### PR TITLE
continued_indentation: Make the E128 check similar to pycodestyle

### DIFF
--- a/autopep8.py
+++ b/autopep8.py
@@ -316,8 +316,9 @@ def continued_indentation(logical_line, tokens, indent_level, hang_closing,
                 if hang_closing:
                     yield (start, 'E133 {}'.format(indent[depth]))
             elif indent[depth] and start[1] < indent[depth]:
-                # Visual indent is broken.
-                yield (start, 'E128 {}'.format(indent[depth]))
+                if visual_indent is not True:
+                    # Visual indent is broken.
+                    yield (start, 'E128 {}'.format(indent[depth]))
             elif (hanging_indent or
                   (indent_next and
                    rel_indent[row] == 2 * DEFAULT_INDENT_SIZE)):

--- a/test/test_autopep8.py
+++ b/test/test_autopep8.py
@@ -1329,7 +1329,7 @@ sql = 'update %s set %s %s' % (from_table,
 
 sql = 'update %s set %s %s' % (from_table,
                                ','.join(['%s=%s' % (col, col)
-                                         for col in cols]),
+                                        for col in cols]),
                                where_clause)
 """
         with autopep8_context(line) as result:


### PR DESCRIPTION
Maybe a simple botch in the following commit:

```
commit 0f06de12f6a1eaab646089f7c38f1d38a035967c
Author: Steven Myint <git@stevenmyint.com>
Date:   Sat Sep 7 12:52:08 2013 -0700

    Get indentation information directly from pep8

    This greatly speeds up the "E12" indentation fixes.
```

A small test case:
```
a = {x: f(x,
     x)
     for x in xs}
```
* autopep8 without this commit complains E128.
* pycodestyle 2.6.0 doesn't complain.
* autopep8 with this commit doesn't complain.