### PR TITLE
Update pycodestyle 2.7.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ from setuptools import setup
 
 
 INSTALL_REQUIRES = (
-    ['pycodestyle >= 2.6.0', 'toml']
+    ['pycodestyle >= 2.7.0', 'toml']
 )
 
 


### PR DESCRIPTION
Hello.

flake8 3.9.0 was released and it's depeneds pycodestyle 2.7.0
However autopep depends pycodestyle 2.6.0

In my project, flake8 and autopep8 has been conflicting.
```
The conflict is caused by:
    autopep8 1.5.5 depends on pycodestyle>=2.6.0
    flake8 3.9.0 depends on pycodestyle<2.8.0 and >=2.7.0
```

This PR updates pycodestyle>=2.7.0

I update pycodestyle 2.7.0 and run tests works fine.
So I think it's OK to update.

Is there any blocker to update pycodestyle 2.7.0?
If update 2.7.0 is OK, please include this and release to PyPi 🙏


```console
$ pip freeze
pycodestyle==2.7.0
toml==0.10.2

$ make test
--->  Running basic test
pycodestyle --repeat .tmp.test.py
--->  Running --diff test
patch < .tmp.example.py.patch
patching file .tmp.example.py
pycodestyle --repeat .tmp.example.py && python -m py_compile .tmp.example.py
--->  Running unit tests
........./tmp/autopep8/autopep8.py:197: PendingDeprecationWarning: lib2to3 package is deprecated and may not be able to parse Python 3.10+
  from lib2to3.pgen2 import tokenize as lib2to3_tokenize
................./opt/local/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/unittest/case.py:550: ResourceWarning: unclosed file <_io.BufferedReader name=3>
  method()
ResourceWarning: Enable tracemalloc to get the object allocation traceback
...............[file:/var/folders/wk/pygq97bn6ssffysmw10b3xb80000gn/T/autopep8test2z2qvu3s/foo.py]
--->  0 issue(s) to fix {}
...............s......................................s.........................s...............................................................................................................................................................................................................................................................................................................................................................s.........................................................................................................
----------------------------------------------------------------------
Ran 579 tests in 41.713s

OK (skipped=4)
```