### PR TITLE
Add Python3.9

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [2.7, 3.6, 3.7, 3.8, pypy2, pypy3]
+        python-version: [2.7, 3.6, 3.7, 3.8, 3.9, pypy2, pypy3]
 
     steps:
     - uses: actions/checkout@v2

--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,7 @@ with io.open('README.rst') as readme:
             'Programming Language :: Python :: 3.6',
             'Programming Language :: Python :: 3.7',
             'Programming Language :: Python :: 3.8',
+            'Programming Language :: Python :: 3.9',
             'Topic :: Software Development :: Libraries :: Python Modules',
             'Topic :: Software Development :: Quality Assurance',
         ],

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=py27,py34,py35,py36,py37,py38
+envlist=py27,py34,py35,py36,py37,py38,py39
 skip_missing_interpreters=True
 
 [testenv]


### PR DESCRIPTION
Add Python3.9 😉 

```
$ tox -e py39         
zsh: correct 'tox' to '_tox' [nyae]? n
GLOB sdist-make: /tmp/autopep8/setup.py
py39 create: /tmp/autopep8/.tox/py39
py39 installdeps: pycodestyle>=2.0, pydiff>=0.1.2
WARNING: Discarding $PYTHONPATH from environment, to override specify PYTHONPATH in 'passenv' in your configuration.
py39 inst: /tmp/autopep8/.tox/.tmp/package/1/autopep8-1.5.6.zip
WARNING: Discarding $PYTHONPATH from environment, to override specify PYTHONPATH in 'passenv' in your configuration.
py39 installed: autopep8==1.5.6,pycodestyle==2.7.0,pydiff==0.2,toml==0.10.2
py39 run-test-pre: PYTHONHASHSEED='2214960521'
py39 run-test: commands[0] | python test/test_autopep8.py
........./tmp/autopep8/autopep8.py:197: PendingDeprecationWarning: lib2to3 package is deprecated and may not be able to parse Python 3.10+
  from lib2to3.pgen2 import tokenize as lib2to3_tokenize
................./opt/local/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/unittest/case.py:550: ResourceWarning: unclosed file <_io.BufferedReader name=3>
  method()
ResourceWarning: Enable tracemalloc to get the object allocation traceback
...............[file:/var/folders/wk/pygq97bn6ssffysmw10b3xb80000gn/T/autopep8test9gmi9_p9/foo.py]
--->  0 issue(s) to fix {}
...............s......................................s.........................s...............................................................................................................................................................................................................................................................................................................................................................s.........................................................................................................
----------------------------------------------------------------------
Ran 579 tests in 27.644s

OK (skipped=4)
py39 run-test: commands[1] | python test/acid.py --aggressive test/example.py
--->  Testing with /tmp/autopep8/test/example.py
/tmp/autopep8/.tox/py39/bin/python /tmp/autopep8/autopep8.py --max-line-length=79 --ignore= /tmp/autopep8/test/example.py --aggressive
py39 run-test: commands[2] | python test/acid.py --compare-bytecode test/example.py
--->  Testing with /tmp/autopep8/test/example.py
/tmp/autopep8/.tox/py39/bin/python /tmp/autopep8/autopep8.py --max-line-length=79 --ignore=E71,E721,W /tmp/autopep8/test/example.py
/var/folders/wk/pygq97bn6ssffysmw10b3xb80000gn/T/tmpvoe1jmfm.py:70:1: E704 multiple statements on one line (def)
def func_oneline(): print(1)
^
autopep8 did not completely fix /tmp/autopep8/test/example.py
___________________________________ summary ____________________________________
  py39: commands succeeded
  congratulations :)
```