### PR TITLE
Document configurable boolean options

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -368,14 +368,18 @@ pyproject.toml
 --------------
 
 autopep8 can also use ``pyproject.toml``.
-section must use ``[tool.autopep8]``, and ``pyproject.toml`` takes precedence
+The section must use ``[tool.autopep8]``, and ``pyproject.toml`` takes precedence
 over any other configuration files.
+Boolean commandline options can be specified as integer 1/0.
 
 configuration file example::
 
     [tool.autopep8]
     max_line_length = 120
     ignore = "E501,W6"  # or ["E501", "W6"]
+    in-place = 1
+    recursive = 1
+    aggressive = 1
 
 
 Testing


### PR DESCRIPTION
This doesn't appear to be documented anywhere I can find online.

I'd also note that you can only specify `aggressive` level 1 in this manner; `aggressive = 2` does not work.