### PR TITLE
Update pycodestyle 2.8.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ from setuptools import setup
 
 
 INSTALL_REQUIRES = (
-    ['pycodestyle >= 2.7.0', 'toml']
+    ['pycodestyle >= 2.8.0', 'toml']
 )
 
 


### PR DESCRIPTION
Hi,

pycodestyle 2.8.0 was released.

```
The conflict is caused by:
    autopep8 1.5.7 depends on pycodestyle>=2.7.0
    flake8 3.9.2 depends on pycodestyle<2.8.0 and >=2.7.0
    The user requested (constraint) pycodestyle==2.8.0
```

I update pycodestyle 2.8.0 and run tests works fine.

```console
make test
--->  Running basic test
pycodestyle --repeat .tmp.test.py
--->  Running --diff test
patch < .tmp.example.py.patch
patching file .tmp.example.py
pycodestyle --repeat .tmp.example.py && python -m py_compile .tmp.example.py
--->  Running unit tests
........../Volumes/Data/platform/github/python/autopep8/autopep8.py:198: PendingDeprecationWarning: lib2to3 package is deprecated and may not be able to parse Python 3.10+
  from lib2to3.pgen2 import tokenize as lib2to3_tokenize
..........--indent-size must be greater than 0........................[file:/var/folders/wk/pygq97bn6ssffysmw10b3xb80000gn/T/autopep8test5oj8z4bd/foo.py]
--->  0 issue(s) to fix {}
...............s......................................s.........................s...................................................................................................................................................................................................................................................................................................................................................................s.........................................................................................................
----------------------------------------------------------------------
Ran 586 tests in 27.115s

OK (skipped=4)

```