### PR TITLE
Use tomli in place of unmaintained toml package

### DIFF
--- a/autopep8.py
+++ b/autopep8.py
@@ -4040,13 +4040,13 @@ def read_config(args, parser):
 
 def read_pyproject_toml(args, parser):
     """Read pyproject.toml and load configuration."""
-    import toml
+    import tomli
 
     config = None
 
     if os.path.exists(args.global_config):
-        with open(args.global_config) as fp:
-            config = toml.load(fp)
+        with open(args.global_config, "rb") as fp:
+            config = tomli.load(fp)
 
     if not args.ignore_local_config:
         parent = tail = args.files and os.path.abspath(
@@ -4054,8 +4054,8 @@ def read_pyproject_toml(args, parser):
         while tail:
             pyproject_toml = os.path.join(parent, "pyproject.toml")
             if os.path.exists(pyproject_toml):
-                with open(pyproject_toml) as fp:
-                    config = toml.load(fp)
+                with open(pyproject_toml, "rb") as fp:
+                    config = tomli.load(fp)
                     break
             (parent, tail) = os.path.split(parent)
 

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ from setuptools import setup
 
 
 INSTALL_REQUIRES = (
-    ['pycodestyle >= 2.9.1', 'toml']
+    ['pycodestyle >= 2.9.1', 'tomli']
 )
 
 


### PR DESCRIPTION
Use the modern `tomli` TOML parser instead of `toml`.  The latter
package is no longer maintained and does not support TOML 1.0.

------
Open question: `tomli` doesn't support Python 2. Do you prefer if I removed Python 2 support entirely, did some conditionals to support `toml` fallback on Python 2 or perhaps simply ignored missing `pyproject.toml` config support in Python 2 and skipped respective tests?