### PR TITLE
Update pycodestyle 2.9.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ from setuptools import setup
 
 
 INSTALL_REQUIRES = (
-    ['pycodestyle >= 2.8.0', 'toml']
+    ['pycodestyle >= 2.9.0', 'toml']
 )
 
 


### PR DESCRIPTION
pycodestyle 2.9.0 was released.

```
The conflict is caused by:
    autopep8 1.6.0 depends on pycodestyle>=2.8.0
    flake8 4.0.1 depends on pycodestyle<2.9.0 and >=2.8.0
    The user requested (constraint) pycodestyle==2.9.0
```

So I bumped dependency version.

Please check and it would be very pleasure to release new version 🙏 🙏 🙏 