### PR TITLE
Drop no longer supported python versions

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [2.7, 3.6, 3.7, 3.8, 3.9, "3.10", pypy2, pypy3]
+        python-version: [3.7, 3.8, 3.9, "3.10", pypy2, pypy3]
 
     steps:
     - uses: actions/checkout@v2

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=py27,py34,py35,py36,py37,py38,py39,py310
+envlist=py37,py38,py39,py310
 skip_missing_interpreters=True
 
 [testenv]


### PR DESCRIPTION
ref https://github.com/hhatto/autopep8/pull/636

```
ERROR: Could not find a version that satisfies the requirement pycodestyle>=2.9.0 (from autopep8==1.6.0) (from versions: 1.8.0.dev0, 2.0.0a1, 2.0.0, 2.1.0, 2.2.0, 2.3.0, 2.3.1, 2.4.0, 2.5.0, 2.6.0a1, 2.6.0, 2.7.0, 2.8.0)
ERROR: No matching distribution found for pycodestyle>=2.9.0 (from autopep8==1.6.0)
```
Unfortunally pycodestyle 2.9.0 does not support old version.
So I think it's time to drop old python version.

This PR remove old python version from GitHub action and tox