### PR TITLE
Fix flake8 error

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [2.7, 3.6, 3.7, 3.8, 3.9, "3.10", pypy2, pypy3]
+        python-version: [3.7, 3.8, 3.9, "3.10", pypy2, pypy3]
 
     steps:
     - uses: actions/checkout@v2

--- a/autopep8.py
+++ b/autopep8.py
@@ -3696,7 +3696,7 @@ def apply_global_fixes(source, options, where='global', filename='',
            for code in ['E101', 'E111']):
         source = reindent(source,
                           indent_size=options.indent_size,
-                          leave_tabs=not(
+                          leave_tabs=not (
                               code_match(
                                     'W191',
                                     select=options.select,

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=py27,py34,py35,py36,py37,py38,py39,py310
+envlist=py37,py38,py39,py310
 skip_missing_interpreters=True
 
 [testenv]


### PR DESCRIPTION
ref #636 #637

CI was failing by flake8 error.
https://github.com/hhatto/autopep8/runs/7632859252?check_suite_focus=true

```
autopep8.py:3699:41: E275 missing whitespace after keyword
```