### PR TITLE
Fix Flake8 E275 error

### DIFF
--- a/autopep8.py
+++ b/autopep8.py
@@ -3696,7 +3696,7 @@ def apply_global_fixes(source, options, where='global', filename='',
            for code in ['E101', 'E111']):
         source = reindent(source,
                           indent_size=options.indent_size,
-                          leave_tabs=not(
+                          leave_tabs=not (
                               code_match(
                                     'W191',
                                     select=options.select,


### PR DESCRIPTION
ref #636 #637

CI was failing by flake8 error.
https://github.com/hhatto/autopep8/runs/7632859252?check_suite_focus=true

```
autopep8.py:3699:41: E275 missing whitespace after keyword
```

This PR just fix flake8 error.
Please check this 🙏 