### PR TITLE
Fix E265 and E266 confusion and overlap

### DIFF
--- a/autopep8.py
+++ b/autopep8.py
@@ -809,7 +809,7 @@ class FixPEP8(object):
         self.source[result['line'] - 1] = fixed
 
     def fix_e262(self, result):
-        """Fix spacing after comment hash."""
+        """Fix spacing after inline comment hash."""
         target = self.source[result['line'] - 1]
         offset = result['column']
 
@@ -817,6 +817,17 @@ class FixPEP8(object):
         comment = target[offset:].lstrip(' \t#')
 
         fixed = code + ('  # ' + comment if comment.strip() else '\n')
+
+        self.source[result['line'] - 1] = fixed
+
+    def fix_e265(self, result):
+        """Fix spacing after block comment hash."""
+        target = self.source[result['line'] - 1]
+
+        indent = _get_indentation(target)
+        comment = target.lstrip(' \t#')
+
+        fixed = indent + ('# ' + comment if comment.strip() else '\n')
 
         self.source[result['line'] - 1] = fixed
 

--- a/autopep8.py
+++ b/autopep8.py
@@ -825,9 +825,12 @@ class FixPEP8(object):
         target = self.source[result['line'] - 1]
 
         indent = _get_indentation(target)
-        comment = target.lstrip(' \t#')
+        line = target.lstrip(' \t')
+        pos = next((index for index, c in enumerate(line) if c != '#'))
+        hashes = line[:pos]
+        comment = line[pos:].lstrip(' \t')
 
-        fixed = indent + ('# ' + comment if comment.strip() else '\n')
+        fixed = indent + hashes + (' ' + comment if comment.strip() else '\n')
 
         self.source[result['line'] - 1] = fixed
 

--- a/autopep8.py
+++ b/autopep8.py
@@ -1685,7 +1685,7 @@ def split_and_strip_non_empty_lines(text):
     return [line.strip() for line in text.splitlines() if line.strip()]
 
 
-def fix_e265(source, aggressive=False):  # pylint: disable=unused-argument
+def fix_e266(source, aggressive=False):  # pylint: disable=unused-argument
     """Format block comments."""
     if '#' not in source:
         # Optimization.

--- a/autopep8.py
+++ b/autopep8.py
@@ -830,6 +830,10 @@ class FixPEP8(object):
         hashes = line[:pos]
         comment = line[pos:].lstrip(' \t')
 
+        # Ignore special comments, even in the middle of the file.
+        if comment.startswith('!'):
+            return
+
         fixed = indent + hashes + (' ' + comment if comment.strip() else '\n')
 
         self.source[result['line'] - 1] = fixed

--- a/test/test_autopep8.py
+++ b/test/test_autopep8.py
@@ -2232,6 +2232,16 @@ bar[zap[0][0]:zig[0][0], :]
         with autopep8_context(line) as result:
             self.assertEqual(fixed, result)
 
+    def test_e265_ignores_special_comments(self):
+        line = "#!python\n456\n"
+        with autopep8_context(line) as result:
+            self.assertEqual(line, result)
+
+    def test_e265_ignores_special_comments_in_middle_of_file(self):
+        line = "123\n\n#!python\n456\n"
+        with autopep8_context(line) as result:
+            self.assertEqual(line, result)
+
     def test_e265_only(self):
         line = "##A comment\n#B comment\n123\n"
         fixed = "## A comment\n# B comment\n123\n"

--- a/test/test_autopep8.py
+++ b/test/test_autopep8.py
@@ -202,23 +202,23 @@ def foo():
     def test_format_block_comments(self):
         self.assertEqual(
             '# abc',
-            autopep8.fix_e266('#abc'))
+            fix_e265_and_e266('#abc'))
 
         self.assertEqual(
             '# abc',
-            autopep8.fix_e266('####abc'))
+            fix_e265_and_e266('####abc'))
 
         self.assertEqual(
             '# abc',
-            autopep8.fix_e266('##   #   ##abc'))
+            fix_e265_and_e266('##   #   ##abc'))
 
         self.assertEqual(
             '# abc "# noqa"',
-            autopep8.fix_e266('# abc "# noqa"'))
+            fix_e265_and_e266('# abc "# noqa"'))
 
         self.assertEqual(
             '# *abc',
-            autopep8.fix_e266('#*abc'))
+            fix_e265_and_e266('#*abc'))
 
     def test_format_block_comments_should_leave_outline_alone(self):
         line = """\
@@ -226,14 +226,14 @@ def foo():
 ##   Some people like these crazy things. So leave them alone.   ##
 ###################################################################
 """
-        self.assertEqual(line, autopep8.fix_e266(line))
+        self.assertEqual(line, fix_e265_and_e266(line))
 
         line = """\
 #################################################################
 #   Some people like these crazy things. So leave them alone.   #
 #################################################################
 """
-        self.assertEqual(line, autopep8.fix_e266(line))
+        self.assertEqual(line, fix_e265_and_e266(line))
 
     def test_format_block_comments_with_multiple_lines(self):
         self.assertEqual(
@@ -247,7 +247,7 @@ def foo():
 #do not modify strings'''
 #
 """,
-            autopep8.fix_e266("""\
+            fix_e265_and_e266("""\
 # abc
   #blah blah
     #four space indentation
@@ -261,17 +261,17 @@ def foo():
     def test_format_block_comments_should_not_corrupt_special_comments(self):
         self.assertEqual(
             '#: abc',
-            autopep8.fix_e266('#: abc'))
+            fix_e265_and_e266('#: abc'))
 
         self.assertEqual(
             '#!/bin/bash\n',
-            autopep8.fix_e266('#!/bin/bash\n'))
+            fix_e265_and_e266('#!/bin/bash\n'))
 
     def test_format_block_comments_should_only_touch_real_comments(self):
         commented_out_code = '#x = 1'
         self.assertEqual(
             commented_out_code,
-            autopep8.fix_e266(commented_out_code))
+            fix_e265_and_e266(commented_out_code))
 
     def test_fix_file(self):
         self.assertIn(
@@ -7504,6 +7504,11 @@ if True:
 """
         with autopep8_context(line, options=['--experimental']) as result:
             self.assertEqual(fixed, result)
+
+
+def fix_e265_and_e266(source):
+    with autopep8_context(source, options=['--select=E265,E266']) as result:
+        return result
 
 
 @contextlib.contextmanager

--- a/test/test_autopep8.py
+++ b/test/test_autopep8.py
@@ -202,23 +202,23 @@ def foo():
     def test_format_block_comments(self):
         self.assertEqual(
             '# abc',
-            autopep8.fix_e265('#abc'))
+            autopep8.fix_e266('#abc'))
 
         self.assertEqual(
             '# abc',
-            autopep8.fix_e265('####abc'))
+            autopep8.fix_e266('####abc'))
 
         self.assertEqual(
             '# abc',
-            autopep8.fix_e265('##   #   ##abc'))
+            autopep8.fix_e266('##   #   ##abc'))
 
         self.assertEqual(
             '# abc "# noqa"',
-            autopep8.fix_e265('# abc "# noqa"'))
+            autopep8.fix_e266('# abc "# noqa"'))
 
         self.assertEqual(
             '# *abc',
-            autopep8.fix_e265('#*abc'))
+            autopep8.fix_e266('#*abc'))
 
     def test_format_block_comments_should_leave_outline_alone(self):
         line = """\
@@ -226,14 +226,14 @@ def foo():
 ##   Some people like these crazy things. So leave them alone.   ##
 ###################################################################
 """
-        self.assertEqual(line, autopep8.fix_e265(line))
+        self.assertEqual(line, autopep8.fix_e266(line))
 
         line = """\
 #################################################################
 #   Some people like these crazy things. So leave them alone.   #
 #################################################################
 """
-        self.assertEqual(line, autopep8.fix_e265(line))
+        self.assertEqual(line, autopep8.fix_e266(line))
 
     def test_format_block_comments_with_multiple_lines(self):
         self.assertEqual(
@@ -247,7 +247,7 @@ def foo():
 #do not modify strings'''
 #
 """,
-            autopep8.fix_e265("""\
+            autopep8.fix_e266("""\
 # abc
   #blah blah
     #four space indentation
@@ -261,17 +261,17 @@ def foo():
     def test_format_block_comments_should_not_corrupt_special_comments(self):
         self.assertEqual(
             '#: abc',
-            autopep8.fix_e265('#: abc'))
+            autopep8.fix_e266('#: abc'))
 
         self.assertEqual(
             '#!/bin/bash\n',
-            autopep8.fix_e265('#!/bin/bash\n'))
+            autopep8.fix_e266('#!/bin/bash\n'))
 
     def test_format_block_comments_should_only_touch_real_comments(self):
         commented_out_code = '#x = 1'
         self.assertEqual(
             commented_out_code,
-            autopep8.fix_e265(commented_out_code))
+            autopep8.fix_e266(commented_out_code))
 
     def test_fix_file(self):
         self.assertIn(

--- a/test/test_autopep8.py
+++ b/test/test_autopep8.py
@@ -2232,10 +2232,34 @@ bar[zap[0][0]:zig[0][0], :]
         with autopep8_context(line) as result:
             self.assertEqual(fixed, result)
 
+    def test_e265_only(self):
+        line = "##A comment\n#B comment\n123\n"
+        fixed = "## A comment\n# B comment\n123\n"
+        with autopep8_context(line, options=['--select=E265']) as result:
+            self.assertEqual(fixed, result)
+
+    def test_ignore_e265(self):
+        line = "## A comment\n#B comment\n123\n"
+        fixed = "# A comment\n#B comment\n123\n"
+        with autopep8_context(line, options=['--ignore=E265']) as result:
+            self.assertEqual(fixed, result)
+
     def test_e266(self):
         line = "## comment\n123\n"
         fixed = "# comment\n123\n"
         with autopep8_context(line) as result:
+            self.assertEqual(fixed, result)
+
+    def test_e266_only(self):
+        line = "## A comment\n#B comment\n123\n"
+        fixed = "# A comment\n#B comment\n123\n"
+        with autopep8_context(line, options=['--select=E266']) as result:
+            self.assertEqual(fixed, result)
+
+    def test_ignore_e266(self):
+        line = "##A comment\n#B comment\n123\n"
+        fixed = "## A comment\n# B comment\n123\n"
+        with autopep8_context(line, options=['--ignore=E266']) as result:
             self.assertEqual(fixed, result)
 
     def test_e271(self):

--- a/test/test_autopep8.py
+++ b/test/test_autopep8.py
@@ -2227,14 +2227,14 @@ bar[zap[0][0]:zig[0][0], :]
             self.assertEqual(fixed, result)
 
     def test_e265(self):
-        line = "## comment\n123\n"
-        fixed = "# comment\n123\n"
+        line = "#A comment\n123\n"
+        fixed = "# A comment\n123\n"
         with autopep8_context(line) as result:
             self.assertEqual(fixed, result)
 
     def test_e266(self):
-        line = "#1 comment\n123\n"
-        fixed = "# 1 comment\n123\n"
+        line = "## comment\n123\n"
+        fixed = "# comment\n123\n"
         with autopep8_context(line) as result:
             self.assertEqual(fixed, result)
 


### PR DESCRIPTION
This rewrites the E265 and E266 fixers to be more like the majority of the other fixers that `autopep8` has (namely that they're now members of the `FixPEP8` class). In doing so it separates how they work, making it possible for users to have neither, either or both fixers enabled.

Reviewing by commit may be useful to understand the changes.

Fixes https://github.com/hhatto/autopep8/issues/649.

The codecov miss here is within `apply_global_fixes` which is doing less now that it really only exists for `W602`.