### PR TITLE
Add 'python_requires=">=3.6"' to match tomli package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,7 @@ with io.open('README.rst') as readme:
         ],
         keywords='automation, pep8, format, pycodestyle',
         install_requires=INSTALL_REQUIRES,
+        python_requires=">=3.6",
         test_suite='test.test_autopep8',
         py_modules=['autopep8'],
         zip_safe=False,


### PR DESCRIPTION
By adding a dependency on the `tomli` packages, which only has versions available for python >=3.6 (>=3.7 for the lastest version at the moment), `autopep8` effectively became compatible with only python >=3.6 also.
This changes reflects that by properly providing the `Requires-Python` package metadata
(https://packaging.python.org/en/latest/guides/dropping-older-python-versions/#specify-the-version-ranges-for-supported-python-distributions).

**Note for maintainers**: After merging and releasing this, you would need to [yank](https://pypi.org/help/#yanked) the `autopep8` 1.7.1 release*, so that python 2 environments stop attempting to install that incompatible version. From that point on, you would be safe and free to keep going py3 only withtout impacting py2 users anymore.
This will make the life of those still using python 2 (or stuck maintaining stuff on it due to unfortunate circumstances out of their control... _cough cough_) that much easier.

\* edit: I now see that you have made a 2.0.0 tag release, which hasn't landed on pypi yet, and with the intent of yanking 1.7.1. You'll need to also yank that 2.0.0 and make a 2.0.1 release with this fix, or something like that. With all those suggestions said, I'll now let you manage your project 😄 .

This addresses issue #655 .

Thanks and cheers!