### PR TITLE
Ignore DeprecationWarnings to fix tests on py3.11

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, "3.10", "pypy3.9"]
+        python-version: [3.7, 3.8, 3.9, "3.10", "3.11", "pypy3.9"]
 
     steps:
     - uses: actions/checkout@v3

--- a/test/test_autopep8.py
+++ b/test/test_autopep8.py
@@ -40,13 +40,14 @@ FAKE_PYCODESTYLE_CONFIGURATION = os.path.join(
 )
 
 if 'AUTOPEP8_COVERAGE' in os.environ and int(os.environ['AUTOPEP8_COVERAGE']):
-    AUTOPEP8_CMD_TUPLE = ('coverage', 'run', '--branch', '--parallel',
+    AUTOPEP8_CMD_TUPLE = (sys.executable, '-Wignore::DeprecationWarning',
+                          '-m', 'coverage', 'run', '--branch', '--parallel',
                           '--omit=*/site-packages/*',
                           os.path.join(ROOT_DIR, 'autopep8.py'),)
 else:
     # We need to specify the executable to make sure the correct Python
     # interpreter gets used.
-    AUTOPEP8_CMD_TUPLE = (sys.executable,
+    AUTOPEP8_CMD_TUPLE = (sys.executable, '-Wignore::DeprecationWarning',
                           os.path.join(ROOT_DIR,
                                        'autopep8.py'),)  # pragma: no cover
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=py37,py38,py39,py310
+envlist=py37,py38,py39,py310,py311
 skip_missing_interpreters=True
 
 [testenv]


### PR DESCRIPTION
Pass `-Wignore::DeprecationWarning` when spawning autopep8 in tests to fix the two test failures when running on Python 3.11:

```
======================================================================
FAIL: test_in_place_no_modifications_no_writes (__main__.CommandLineTests.test_in_place_no_modifications_no_writes)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/tmp/autopep8/test/test_autopep8.py", line 5518, in test_in_place_no_modifications_no_writes
    self.assertEqual(err, b'')
AssertionError: b'/tmp/autopep8/autopep8.py:182: Deprecatio[137 chars]ze\n' != b''

======================================================================
FAIL: test_in_place_no_modifications_no_writes_with_empty_file (__main__.CommandLineTests.test_in_place_no_modifications_no_writes_with_empty_file)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/tmp/autopep8/test/test_autopep8.py", line 5530, in test_in_place_no_modifications_no_writes_with_empty_file
    self.assertEqual(err, b'')
AssertionError: b'/tmp/autopep8/autopep8.py:182: Deprecatio[137 chars]ze\n' != b''
```

This is a temporary fix until issue #581 is resolved.