### PR TITLE
add pre-commit configuration

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,7 @@
+-   id: autopep8
+    name: autopep8
+    description: A tool that automatically formats Python code to conform to the PEP 8 style guide.
+    entry: autopep8
+    language: python
+    types: [python]
+    args: [-i]

--- a/README.rst
+++ b/README.rst
@@ -384,6 +384,23 @@ configuration file example::
     recursive = true
     aggressive = 3
 
+Usage with pre-commit
+=====================
+
+autopep8 can be used as a hook for pre-commit_.
+
+To add autopep8 as a plugin, add this repo definition to your configuration:
+
+.. code-block:: yaml
+
+    repos:
+    -   repo: https://github.com/hhatto/autopep8
+        rev: ...  # select the tag or revision you want, or run `pre-commit autoupdate`
+        hooks:
+        -   id: autopep8
+
+.. _`pre-commit`: https://pre-commit.com
+
 
 Testing
 =======


### PR DESCRIPTION
resolves #678

checked that it worked with `pre-commit try-repo`:

```console
$ pre-commit try-repo . --files autopep8.py 
[INFO] Initializing environment for ..
===============================================================================
Using config:
===============================================================================
repos:
-   repo: .
    rev: 3c1e0e4e42132e64f9fb088462aab3358677b55b
    hooks:
    -   id: autopep8
===============================================================================
[INFO] Installing environment for ..
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
autopep8.................................................................Failed
- hook id: autopep8
- files were modified by this hook
```
```diff
$ git diff
diff --git a/autopep8.py b/autopep8.py
index 573f7ac..607899d 100755
--- a/autopep8.py
+++ b/autopep8.py
@@ -3662,10 +3662,10 @@ def apply_global_fixes(source, options, where='global', filename='',
                           indent_size=options.indent_size,
                           leave_tabs=not (
                               code_match(
-                                    'W191',
-                                    select=options.select,
-                                    ignore=options.ignore)
-                                         )
+                                  'W191',
+                                  select=options.select,
+                                  ignore=options.ignore)
+                          )
                           )
 
     for (code, function) in global_fixes():
```