### PR TITLE
Update MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -13,6 +13,7 @@ include test/iso_8859_1.py
 include test/fake_configuration/.pep8
 include test/fake_pycodestyle_configuration/tox.ini
 include tox.ini
+include .pre-commit-hooks.yaml
 recursive-exclude test/suite *.py
 recursive-exclude test/suite/out *.py
 exclude .travis.yml


### PR DESCRIPTION
Added missing .pre-commit-hooks.yaml to fix broken external usage. This minimal change solve the issue described [here](https://github.com/hhatto/autopep8/issues/692).