### PR TITLE
Fixed 'missing_whitespace_around_operator' rename.

### DIFF
--- a/autopep8.py
+++ b/autopep8.py
@@ -758,7 +758,7 @@ class FixPEP8(object):
             if not check_syntax(fixed.lstrip()):
                 return
             errors = list(
-                pycodestyle.missing_whitespace_around_operator(fixed, ts))
+                pycodestyle.missing_whitespace(fixed, ts))
             for e in reversed(errors):
                 if error_code != e[1].split()[0]:
                     continue


### PR DESCRIPTION
doctest failed with `AttributeError: module 'pycodestyle' has no attribute 'missing_whitespace_around_operator'` due to a rename of the function in pycodestyle. Updated autopep8.py to use the correct function name.