### PR TITLE
Paugier fix pycodestyle missing whitespace

### DIFF
--- a/autopep8.py
+++ b/autopep8.py
@@ -84,7 +84,6 @@ import tokenize
 import warnings
 import ast
 from configparser import ConfigParser as SafeConfigParser, Error
-from packaging.version import parse as parse_version
 
 import pycodestyle
 from pycodestyle import STARTSWITH_INDENT_STATEMENT_REGEX

--- a/autopep8.py
+++ b/autopep8.py
@@ -757,8 +757,14 @@ class FixPEP8(object):
                 return
             if not check_syntax(fixed.lstrip()):
                 return
-            errors = list(
-                pycodestyle.missing_whitespace_around_operator(fixed, ts))
+            try:
+                _missing_whitespace = (
+                    pycodestyle.missing_whitespace_around_operator
+                )
+            except AttributeError:
+                # pycodestyle >= 2.11.0
+                _missing_whitespace = pycodestyle.missing_whitespace
+            errors = list(_missing_whitespace(fixed, ts))
             for e in reversed(errors):
                 if error_code != e[1].split()[0]:
                     continue


### PR DESCRIPTION
base pull-request is #699 . thanks for @paugier

I apologize.
I mistakenly thought the `packaging` module was a standard module.
I will make corrections to incorporate pull-request #699.