### PR TITLE
Revert "Update MANIFEST.in"

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -13,7 +13,6 @@ include test/iso_8859_1.py
 include test/fake_configuration/.pep8
 include test/fake_pycodestyle_configuration/tox.ini
 include tox.ini
-include .pre-commit-hooks.yaml
 recursive-exclude test/suite *.py
 recursive-exclude test/suite/out *.py
 exclude .travis.yml


### PR DESCRIPTION
Reverts hhatto/autopep8#693

Merged #693 pull-request to resolve issue #692, but no changes were necessary to include `.pre-commit-hooks.yaml` in this `MANIFEST.in` file.
The solution to #692 was to use autopep8 v2.0.3 or later.
Therefore, the change in #693 is revert.