### PR TITLE
ISSUE_TEMPLATE: use "console" instead of non-existing "shell" syntax

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -16,7 +16,7 @@ YOUR CODE
 ```
 
 Command Line
-```shell
+```console
 $ autopep8 
 ```
 


### PR DESCRIPTION
<code>&#96;&#96;&#96;shell</code> does not exist.
<code>&#96;&#96;&#96;sh</code> is what you use to highlight (UNIX) shell scripts, and <code>&#96;&#96;&#96;console</code> is what you use to highlight command lines.