### PR TITLE
Fix to use the function fix_file() separately with options parameter

### DIFF
--- a/autopep8.py
+++ b/autopep8.py
@@ -3585,7 +3585,8 @@ def fix_file(filename, options=None, output=None, apply_config=False):
     original_source = readlines_from_file(filename)
 
     fixed_source = original_source
-    # Fix to use the function fix_file separately from python script with options as parameter
+    # Fix to use the function fix_file separately from python 
+    # script with options as parameter
     if isinstance(options, dict):
         options = _get_options(options, apply_config)
 

--- a/autopep8.py
+++ b/autopep8.py
@@ -3585,6 +3585,9 @@ def fix_file(filename, options=None, output=None, apply_config=False):
     original_source = readlines_from_file(filename)
 
     fixed_source = original_source
+    # Fix to use the function fix_file separately from python script with options as parameter
+    if isinstance(options, dict):
+        options = _get_options(options, apply_config)
 
     if options.in_place or options.diff or output:
         encoding = detect_encoding(filename)

--- a/autopep8.py
+++ b/autopep8.py
@@ -3585,7 +3585,7 @@ def fix_file(filename, options=None, output=None, apply_config=False):
     original_source = readlines_from_file(filename)
 
     fixed_source = original_source
-    # Fix to use the function fix_file separately from python 
+    # Fix to use the function fix_file separately from python
     # script with options as parameter
     if isinstance(options, dict):
         options = _get_options(options, apply_config)


### PR DESCRIPTION
Resolved issue (`AttributeError: 'dict' object has no attribute 'in_place' if tried` ) for using `fix_file()` in python script with options as dictionary.

Can use `autopep8.fix_file(python_file_name, options={'in_place': True, "aggressive": 2}, apply_config=True)` now.

Details as per guidelines:
1. Does not involve `pycodestyle` tool

2. autopep8 --version
`autopep8 2.0.4`

3. pycodestyle --version
`2.11.1`

4. python --version
`Python 3.11.4`

5. Not on Unix

6. Error while using below code directly using imports
`autopep8.fix_file(python_file_name, options={'in_place': True, "aggressive": 2}, apply_config=True)`
Getting: `AttributeError: 'dict' object has no attribute 'in_place'`

7. Not using autopep8 command

8. The implementation should not raise an error 

9. Using the latest release 
