### PR TITLE
tox: add python3.12 to test environments

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=py37,py38,py39,py310,py311
+envlist=py37,py38,py39,py310,py311,py312
 skip_missing_interpreters=True
 
 [testenv]


### PR DESCRIPTION
Trying to get to the bottom of issue#712 I think it is good to run the testsuite against py312 - it seems fine and I'm still in the dark why the issues are observed in #712  but this trivial PR seems like a useful starting point :)