### PR TITLE
pyproject: support py3.12 via new version of pycodestyle

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ classifiers = [
 ]
 requires-python = ">=3.6"
 dependencies = [
-    "pycodestyle >= 2.10.0",
+    "pycodestyle >= 2.11.0",
     "tomli; python_version < '3.11'",
 ]
 dynamic = ["version"]


### PR DESCRIPTION
autopep8 had some issues with python3.12. It seems just moving to the latest version of pycodestyle does fix the issue.

Closes: https://github.com/hhatto/autopep8/issues/712
Thanks: "hruskape" on github