### PR TITLE
add handling for E204 whitespace after decorator

### DIFF
--- a/autopep8.py
+++ b/autopep8.py
@@ -509,6 +509,7 @@ class FixPEP8(object):
         self.fix_e133 = self.fix_e131
         self.fix_e202 = self.fix_e201
         self.fix_e203 = self.fix_e201
+        self.fix_e204 = self.fix_e201
         self.fix_e211 = self.fix_e201
         self.fix_e221 = self.fix_e271
         self.fix_e222 = self.fix_e271

--- a/test/test_autopep8.py
+++ b/test/test_autopep8.py
@@ -1859,6 +1859,12 @@ c
         with autopep8_context(line, options=['--select=E203']) as result:
             self.assertEqual(fixed, result)
 
+    def test_e204(self):
+        line = '@ decorator\n'
+        fixed = '@decorator\n'
+        with autopep8_context(line, options=['--select=E204']) as result:
+            self.assertEqual(fixed, result)
+
     def test_e211(self):
         line = 'd = [1, 2, 3]\nprint(d  [0])\n'
         fixed = 'd = [1, 2, 3]\nprint(d[0])\n'


### PR DESCRIPTION
this is to handle the future error code E204 which is implemented here: https://github.com/PyCQA/pycodestyle/pull/1247

fortunately this was very easy to add support for here!