### PR TITLE
Fix AssertionError crash on long line fragment with trailing comment (#784)

### DIFF
--- a/autopep8.py
+++ b/autopep8.py
@@ -2833,6 +2833,29 @@ def _reflow_lines(parsed_tokens, indentation, max_line_length,
     return lines.emit()
 
 
+def _tokens_have_balanced_brackets(tokens):
+    """Return True if the brackets in the tokens open and close cleanly.
+
+    The reflow machinery (``ReformattedLines``) assumes every closing
+    bracket has a matching opening bracket earlier in the same token
+    stream. A physical line that is only a fragment of a larger
+    multi-line statement can start or end in the middle of a bracket,
+    which would make the running depth go negative (or leave it above
+    zero at the end) and trigger an ``AssertionError`` during reflow.
+
+    """
+    depth = 0
+    for tok in tokens:
+        token_string = tok[1]
+        if token_string in ('(', '[', '{'):
+            depth += 1
+        elif token_string in (')', ']', '}'):
+            depth -= 1
+            if depth < 0:
+                return False
+    return depth == 0
+
+
 def _shorten_line_at_tokens_new(tokens, source, indentation,
                                 max_line_length):
     """Shorten the line taking its length into account.
@@ -2844,6 +2867,12 @@ def _shorten_line_at_tokens_new(tokens, source, indentation,
     # Yield the original source so to see if it's a better choice than the
     # shortened candidate lines we generate here.
     yield indentation + source
+
+    if not _tokens_have_balanced_brackets(tokens):
+        # The tokens are only a fragment of a larger multi-line statement
+        # (unbalanced brackets). Reflowing them would drive the bracket
+        # depth negative and crash, so leave the line unchanged.
+        return
 
     parsed_tokens = _parse_tokens(tokens)
 

--- a/test/test_autopep8.py
+++ b/test/test_autopep8.py
@@ -6182,6 +6182,29 @@ print(111, 111, 111, 111, 222, 222, 222, 222,
         with autopep8_context(line, options=['--experimental']) as result:
             self.assertEqual(fixed, result)
 
+    def test_e501_experimental_with_unbalanced_multiline_fragment(self):
+        # A long physical line that is only a fragment of a larger
+        # multi-line statement has unbalanced brackets. Reflowing it used
+        # to drive the bracket depth negative and raise an AssertionError
+        # (see issue #784). It should be handled gracefully instead.
+        line = """\
+def do_tables(metadata):
+    x = SomeTable('test', metadata,
+                  Column('col_a', SmallInteger, nullable=False, default=some_model_name.SomeClassName.REVIEW_STATUS_UNAVAILABLE),
+                  Column('col_b', Boolean, nullable=False),  # some comment
+                  )
+"""
+        fixed = """\
+def do_tables(metadata):
+    x = SomeTable('test', metadata,
+                  Column('col_a', SmallInteger, nullable=False,
+                         default=some_model_name.SomeClassName.REVIEW_STATUS_UNAVAILABLE),
+                  Column('col_b', Boolean, nullable=False),  # some comment
+                  )
+"""
+        with autopep8_context(line, options=['--experimental']) as result:
+            self.assertEqual(fixed, result)
+
     def test_e501_experimental_with_commas_and_colons(self):
         line = """\
 foobar = {'aaaaaaaaaaaa': 'bbbbbbbbbbbbbbbb', 'dddddd': 'eeeeeeeeeeeeeeee', 'ffffffffffff': 'gggggggg'}


### PR DESCRIPTION
## Summary

`autopep8` crashes with `AssertionError: assert self._bracket_depth >= 0` on an over-length line that ends in a trailing comment when the line is part of a larger multi-line statement (issue #784).

The over-long physical line handled by `fix_long_line_physically` can be only a *fragment* of a bigger multi-line statement, so its brackets are unbalanced (e.g. `nullable=False, default=...),` closes a `)` that was never opened in that fragment). The experimental reflow machinery (`_shorten_line_at_tokens_new` → `_reflow_lines` → `ReformattedLines._add_item`) assumes every closing bracket has a matching opening bracket earlier in the same token stream. On an unbalanced fragment the running `_bracket_depth` goes negative and the `assert self._bracket_depth >= 0` fires, aborting the whole run.

Removing the trailing comment happened to change which fix path was taken, which is why the crash appeared to depend on the comment.

## Fix

Add a small helper `_tokens_have_balanced_brackets(tokens)` and use it in `_shorten_line_at_tokens_new` to detect token streams whose brackets do not open and close cleanly. When the brackets are unbalanced (a fragment of a multi-line statement), the reflow cannot succeed, so the function now leaves the line unchanged instead of driving the bracket depth negative and crashing. Balanced lines are unaffected.

## Tests / Verification

- Added regression test `ExperimentalSystemTests.test_e501_experimental_with_unbalanced_multiline_fragment`, using the reproducer from the issue. It fails on the current code with the exact `AssertionError` and passes with the fix.
- Full suite green: `python test/test_autopep8.py` — 568 tests, OK (7 pre-existing environment skips).
- Lint clean: `flake8 autopep8.py` and `pycodestyle autopep8.py` both pass (the change is confined to `autopep8.py`).
- CI acid check passes: `python test/acid.py --pycodestyle= -aaa --compare-bytecode --experimental test/example.py`.
- The original reproducer (`autopep8 --max-line-length=120 --experimental test.py`) now exits 0 and produces valid, idempotent output.

Disclosure: prepared with AI assistance; reviewed and verified locally.
